### PR TITLE
Add new affordable S3 storage provider

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -53,7 +53,7 @@ body {
 
 .providerIcon {
   width: 120px;
-  height: 100px;
+  height: 110px;
   margin: 10px;
   vertical-align: middle;
 }

--- a/src/SetupRepository.js
+++ b/src/SetupRepository.js
@@ -24,7 +24,7 @@ import { SetupWebDAV } from './SetupWebDAV';
 const supportedProviders = [
     { provider: "filesystem", description: "Filesystem", component: SetupFilesystem },
     { provider: "gcs", description: "Google Cloud Storage", component: SetupGCS },
-    { provider: "s3", description: "Amazon S3, Minio, Wasabi, etc.", component: SetupS3 },
+    { provider: "s3", description: "Amazon S3, IDrive e2, Minio, Wasabi, etc.", component: SetupS3 },
     { provider: "b2", description: "Backblaze B2", component: SetupB2 },
     { provider: "azureBlob", description: "Azure Blob Storage", component: SetupAzure },
     { provider: "sftp", description: "SFTP server", component: SetupSFTP },


### PR DESCRIPTION
Found IDrive e2: the cheapest cloud storage in the market with no fees for egress. We use kopia for backups so tested extensively with kopia and found it to be way faster than other s3 providers like Backblaze B2, Wasabi etc. It deserves a place in this amazing tool.