### PR TITLE
Update SetupGCS.js

### DIFF
--- a/src/SetupGCS.js
+++ b/src/SetupGCS.js
@@ -26,9 +26,6 @@ export class SetupGCS extends Component {
             <Row>
                 {OptionalField(this, "Credentials File", "credentialsFile", { placeholder: "enter name of credentials JSON file" })}
             </Row>
-            <Row>
-                {OptionalField(this, "Credentials JSON", "credentials", { placeholder: "paste JSON credentials here", as: "textarea", rows: 5 })}
-            </Row>
         </>;
     }
 }


### PR DESCRIPTION
KopiaUI throws an error when trying to connect to GCS by pasting in JSON credentials in the textarea; it throws the error: "Connect Error: INTERNAL: internal server error: unable to initialize token source: google.JWTConfigFromJSON: json: cannot unmarshal string into Go value of type google.credentialsFile"

Connecting to GCS works just fine when putting the same JSON credentials in a JSON file and loading the JSON file into KopiaUI. Until someone can tackle the error, I propose simply removing the JSON textarea -- it is not really critical and people can connect to GCS by using a JSON file instead.