### PR TITLE
Button to write restored snapshot files sparsely

### DIFF
--- a/src/BeginRestore.js
+++ b/src/BeginRestore.js
@@ -24,6 +24,7 @@ export class BeginRestore extends Component {
             overwriteSymlinks: false,
             ignorePermissionErrors: true,
             writeFilesAtomically: false,
+            writeFilesSparsely: false,
             restoreDirEntryAtDepth: 1000,
             minSizeForPlaceholder: 0,
             restoreTask: "",
@@ -68,7 +69,8 @@ export class BeginRestore extends Component {
                 overwriteFiles: this.state.overwriteFiles,
                 overwriteDirectories: this.state.overwriteDirectories,
                 overwriteSymlinks: this.state.overwriteSymlinks,
-                writeFilesAtomically: this.state.writeFilesAtomically
+                writeFilesAtomically: this.state.writeFilesAtomically,
+                sparse: this.state.writeFilesSparsely,
             }
         }
 
@@ -127,6 +129,9 @@ export class BeginRestore extends Component {
                 </Row>
                 <Row>
                     {RequiredBoolean(this, "Write files atomically", "writeFilesAtomically")}
+                </Row>
+                <Row>
+                    {RequiredBoolean(this, "Write files sparsely", "writeFilesSparsely")}
                 </Row>
                 <Row>
                     <Col><hr/></Col>


### PR DESCRIPTION
This commit adds a new radial button (required value) to the snapshot
restore window allowing users to enable the sparse restore option.
When enabled, the restored snapshot's files are written sparsely,
minimizing disk allocations for the written content. This option is
disabled by default.