### PR TITLE
Refine appearance of "Create New Repository" form

### DIFF
--- a/src/SetupRepository.js
+++ b/src/SetupRepository.js
@@ -310,17 +310,18 @@ export class SetupRepository extends Component {
     }
 
     toggleAdvancedButton() {
+        // Determine button icon and text based upon component state.
+        const icon = this.state.showAdvanced ? faAngleDoubleUp : faAngleDoubleDown;
+        const text = this.state.showAdvanced ? "Hide Advanced Options" : "Show Advanced Options";
+
         return <Button data-testid='advanced-options' onClick={this.toggleAdvanced}
             variant="secondary"
             aria-controls="advanced-options-div"
             aria-expanded={this.state.showAdvanced}
             size="sm"
         >
-            {!this.state.showAdvanced ? <>
-                <FontAwesomeIcon icon={faAngleDoubleDown} />&nbsp;Show Advanced Options
-                            </> : <>
-                <FontAwesomeIcon icon={faAngleDoubleUp} />&nbsp;Hide Advanced Options
-                            </>}
+            <FontAwesomeIcon icon={icon} style={{ marginRight: 4 }} />
+            {text}
         </Button>;
     }
 
@@ -332,9 +333,11 @@ export class SetupRepository extends Component {
                 {RequiredField(this, "Repository Password", "password", { autoFocus: true, type: "password", placeholder: "enter repository password" }, "The password used to encrypt repository contents.")}
                 {RequiredField(this, "Confirm Repository Password", "confirmPassword", { type: "password", placeholder: "enter repository password again" })}
             </Row>
-            {this.toggleAdvancedButton()}
+            <div style={{ marginTop: "1rem" }}>
+                {this.toggleAdvancedButton()}
+            </div>
             <Collapse in={this.state.showAdvanced}>
-                <div id="advanced-options-div">
+                <div id="advanced-options-div" style={{ marginTop: "1rem" }}>
                     <Row>
                         <Form.Group as={Col}>
                             <Form.Label className="required">Encryption</Form.Label>
@@ -379,9 +382,9 @@ export class SetupRepository extends Component {
                         </Form.Group>
                     </Row>
                     {this.overrideUsernameHostnameRow()}
-                    <Row>
+                    <Row style={{ marginTop: "1rem" }}>
                         <Form.Group as={Col}>
-                            <Form.Text>Additional parameters can be set when creating repository using command line</Form.Text>
+                            <Form.Text>Additional parameters can be set when creating repository using command line.</Form.Text>
                         </Form.Group>
                     </Row>
                 </div>


### PR DESCRIPTION
### Changes

- Added vertical space between the "Repository Password" help text and the "Show/Hide Advanced Options" button
- Added vertical space between the "Show/Hide Advanced Options" button and the form it reveals/conceals
- Replaced a `&nbsp;` character being used for layout, with `margin` (so code is more "semantically accurate")
- Added vertical space between the form and the "Additional parameters..." footnote
- Added a period (`.`) to the end of a sentence

### Screenshots

#### Before

![image](https://user-images.githubusercontent.com/7143133/174189555-43c17fcf-f63a-45bb-9b5b-cf629a121df1.png)

#### After

Note: The window was slightly larger for this screenshot, so the page elements appear slightly smaller than above.

![image](https://user-images.githubusercontent.com/7143133/174190008-f70e751d-9435-456a-902f-51ccb6a49950.png)
