### PR TITLE
Display task status durations using larger time units

### DIFF
--- a/src/TasksTable.js
+++ b/src/TasksTable.js
@@ -105,13 +105,13 @@ export class TasksTable extends Component {
 
         const columns = [{
             Header: 'Start Time',
-            width: 200,
+            width: 160,
             accessor: x => <Link to={'/tasks/' + x.id} title={moment(x.startTime).toLocaleString()}>
                 {moment(x.startTime).fromNow()}
             </Link>
         }, {
             Header: 'Status',
-            width: 200,
+            width: 240,
             accessor: x => taskStatusSymbol(x),
         }, {
             Header: 'Kind',

--- a/src/tests/uiutil.test.js
+++ b/src/tests/uiutil.test.js
@@ -1,4 +1,4 @@
-import { formatMilliseconds } from "../uiutil";
+import { formatMilliseconds, separateMillisecondsIntoMultipleUnits, formatMultipleUnits } from "../uiutil";
 
 describe("formatMilliseconds", () => {
     it("uses 'XXs' format by default", () => {
@@ -10,26 +10,145 @@ describe("formatMilliseconds", () => {
     });
 
     it("uses humanized format if flag is set", () => {
-        // Exactly 1ms, 1s, 1m, 1h, 1d:
-        expect(formatMilliseconds(        1, true)).toBe("a few seconds");
-        expect(formatMilliseconds(    1_000, true)).toBe("a few seconds");
-        expect(formatMilliseconds(   60_000, true)).toBe("a minute");
-        expect(formatMilliseconds( 3600_000, true)).toBe("an hour");
-        expect(formatMilliseconds(86400_000, true)).toBe("a day");
+        expect(formatMilliseconds(        1, true)).toBe("0.001 seconds");
+        expect(formatMilliseconds(    1_000, true)).toBe("1 seconds");
+        expect(formatMilliseconds(   60_000, true)).toBe("1 minutes 0 seconds");
+        expect(formatMilliseconds( 3600_000, true)).toBe("1 hours 0 minutes");
+        expect(formatMilliseconds(86400_000, true)).toBe("1 days 0 hours");
+    });
+});
 
-        // Edge cases (and some non-edge cases):
-        expect(formatMilliseconds(        1, true)).toBe("a few seconds");
-        expect(formatMilliseconds(   44_499, true)).toBe("a few seconds");
-        expect(formatMilliseconds(   44_500, true)).toBe("a minute");
-        expect(formatMilliseconds(   89_999, true)).toBe("a minute");
-        expect(formatMilliseconds(   90_000, true)).toBe("2 minutes");
-        expect(formatMilliseconds(  149_999, true)).toBe("2 minutes");
-        expect(formatMilliseconds(  150_000, true)).toBe("3 minutes");
-        expect(formatMilliseconds( 1800_000, true)).toBe("30 minutes");
-        expect(formatMilliseconds( 2400_000, true)).toBe("40 minutes");
-        expect(formatMilliseconds( 2640_000, true)).toBe("44 minutes");
-        expect(formatMilliseconds( 2669_999, true)).toBe("44 minutes");
-        expect(formatMilliseconds( 2670_000, true)).toBe("an hour"); // 44m 30s
-        expect(formatMilliseconds( 3200_000, true)).toBe("an hour");
+describe("separateMillisecondsIntoMultipleUnits", () => {
+    // Concise alias for function-under-test.
+    const fn = separateMillisecondsIntoMultipleUnits;
+
+    it("handles 0 milliseconds", () => {
+        expect(fn(0)).toMatchObject({
+            days: 0,
+            hours: 0,
+            minutes: 0,
+            seconds: 0,
+            milliseconds: 0,
+        });
+    });
+
+    it("includes all units from days to milliseconds", () => {
+        expect(fn(3601000)).toMatchObject({
+            days: 0,
+            hours: 1,
+            minutes: 0,
+            seconds: 1,
+            milliseconds: 0,
+        });
+    });
+
+    it("omits partial milliseconds from result", () => {
+        expect(fn(100000123.999)).toMatchObject({
+            days: 1,
+            hours: 3,
+            minutes: 46,
+            seconds: 40,
+            milliseconds: 123, // omits the partial millisecond (.999)
+        });
+    });
+});
+
+describe("formatMultipleUnits", () => {
+    let magnitudes;
+
+    // Concise alias for function-under-test.
+    const fn = formatMultipleUnits;
+
+    it("represents durations (T < 1 second) using seconds (fractional)", () => {
+        magnitudes = { days: 0, hours: 0, minutes: 0, seconds: 0, milliseconds: 0 };
+        expect(fn(magnitudes)).toBe("0 seconds");
+
+        magnitudes = { days: 0, hours: 0, minutes: 0, seconds: 0, milliseconds: 1 };
+        expect(fn(magnitudes)).toBe("0.001 seconds");
+
+        magnitudes = { days: 0, hours: 0, minutes: 0, seconds: 0, milliseconds: 10 };
+        expect(fn(magnitudes)).toBe("0.01 seconds");
+
+        magnitudes = { days: 0, hours: 0, minutes: 0, seconds: 0, milliseconds: 100 };
+        expect(fn(magnitudes)).toBe("0.1 seconds");
+
+        magnitudes = { days: 0, hours: 0, minutes: 0, seconds: 0, milliseconds: 999 };
+        expect(fn(magnitudes)).toBe("0.999 seconds");
+    });
+
+    it("represents durations (1 second <= T < 10 seconds) using seconds (fractional)", () => {
+        magnitudes = { days: 0, hours: 0, minutes: 0, seconds: 1, milliseconds: 0 };
+        expect(fn(magnitudes)).toBe("1 seconds");
+
+        magnitudes = { days: 0, hours: 0, minutes: 0, seconds: 1, milliseconds: 1 };
+        expect(fn(magnitudes)).toBe("1.001 seconds");
+
+        magnitudes = { days: 0, hours: 0, minutes: 0, seconds: 1, milliseconds: 10 };
+        expect(fn(magnitudes)).toBe("1.01 seconds");
+
+        magnitudes = { days: 0, hours: 0, minutes: 0, seconds: 1, milliseconds: 100 };
+        expect(fn(magnitudes)).toBe("1.1 seconds");
+
+        magnitudes = { days: 0, hours: 0, minutes: 0, seconds: 9, milliseconds: 999 };
+        expect(fn(magnitudes)).toBe("9.999 seconds");
+    });
+
+    it("represents durations (10 seconds <= T < 1 minute) using seconds (integer)", () => {
+        magnitudes = { days: 0, hours: 0, minutes: 0, seconds: 10, milliseconds: 0 };
+        expect(fn(magnitudes)).toBe("10 seconds");
+
+        magnitudes = { days: 0, hours: 0, minutes: 0, seconds: 10, milliseconds: 999 };
+        expect(fn(magnitudes)).toBe("10 seconds");
+
+        magnitudes = { days: 0, hours: 0, minutes: 0, seconds: 11, milliseconds: 0 };
+        expect(fn(magnitudes)).toBe("11 seconds");
+
+        magnitudes = { days: 0, hours: 0, minutes: 0, seconds: 59, milliseconds: 999 };
+        expect(fn(magnitudes)).toBe("59 seconds");
+    });
+
+    it("represents durations (1 minute <= T < 1 hour) using minutes (integer) and seconds (integer)", () => {
+        magnitudes = { days: 0, hours: 0, minutes: 1, seconds: 0, milliseconds: 0 };
+        expect(fn(magnitudes)).toBe("1 minutes 0 seconds");
+
+        magnitudes = { days: 0, hours: 0, minutes: 1, seconds: 0, milliseconds: 999 };
+        expect(fn(magnitudes)).toBe("1 minutes 0 seconds");
+
+        magnitudes = { days: 0, hours: 0, minutes: 1, seconds: 1, milliseconds: 0 };
+        expect(fn(magnitudes)).toBe("1 minutes 1 seconds");
+
+        magnitudes = { days: 0, hours: 0, minutes: 59, seconds: 59, milliseconds: 999 };
+        expect(fn(magnitudes)).toBe("59 minutes 59 seconds");
+    });
+
+    it("represents durations (1 hour <= T < 1 day) using hours (integer) and minutes (integer)", () => {
+        magnitudes = { days: 0, hours: 1, minutes: 0, seconds: 0, milliseconds: 0 };
+        expect(fn(magnitudes)).toBe("1 hours 0 minutes");
+
+        magnitudes = { days: 0, hours: 1, minutes: 0, seconds: 59, milliseconds: 999 };
+        expect(fn(magnitudes)).toBe("1 hours 0 minutes");
+
+        magnitudes = { days: 0, hours: 1, minutes: 1, seconds: 0, milliseconds: 0 };
+        expect(fn(magnitudes)).toBe("1 hours 1 minutes");
+
+        magnitudes = { days: 0, hours: 23, minutes: 59, seconds: 59, milliseconds: 999 };
+        expect(fn(magnitudes)).toBe("23 hours 59 minutes");
+    });
+
+    it("represents durations (T >= 1 day) using days (integer) and hours (integer)", () => {
+        magnitudes = { days: 1, hours: 0, minutes: 0, seconds: 0, milliseconds: 0 };
+        expect(fn(magnitudes)).toBe("1 days 0 hours");
+
+        magnitudes = { days: 1, hours: 0, minutes: 59, seconds: 59, milliseconds: 999 };
+        expect(fn(magnitudes)).toBe("1 days 0 hours");
+
+        magnitudes = { days: 1, hours: 1, minutes: 0, seconds: 0, milliseconds: 0 };
+        expect(fn(magnitudes)).toBe("1 days 1 hours");
+
+        magnitudes = { days: 1, hours: 23, minutes: 59, seconds: 59, milliseconds: 999 };
+        expect(fn(magnitudes)).toBe("1 days 23 hours");
+
+        magnitudes = { days: 7, hours: 0, minutes: 0, seconds: 0, milliseconds: 0 };
+        expect(fn(magnitudes)).toBe("7 days 0 hours"); // no special treatment for a week
     });
 });

--- a/src/tests/uiutil.test.js
+++ b/src/tests/uiutil.test.js
@@ -1,4 +1,4 @@
-import { formatMilliseconds, separateMillisecondsIntoMultipleUnits, formatMultipleUnits } from "../uiutil";
+import { formatMilliseconds, separateMillisecondsIntoMagnitudes, formatMagnitudesUsingMultipleUnits } from "../uiutil";
 
 describe("formatMilliseconds", () => {
     it("uses 'XXs' format by default", () => {
@@ -9,18 +9,18 @@ describe("formatMilliseconds", () => {
         expect(formatMilliseconds(86400_000)).toBe("86400s"); // 1d
     });
 
-    it("uses humanized format if flag is set", () => {
-        expect(formatMilliseconds(        1, true)).toBe("0.0 seconds");
-        expect(formatMilliseconds(    1_000, true)).toBe("1.0 seconds");
-        expect(formatMilliseconds(   60_000, true)).toBe("1 minute 0 seconds");
-        expect(formatMilliseconds( 3600_000, true)).toBe("1 hour 0 minutes");
-        expect(formatMilliseconds(86400_000, true)).toBe("1 day 0 hours");
+    it("uses multi-unit format if flag is set", () => {
+        expect(formatMilliseconds(        1, true)).toBe("0.0s");
+        expect(formatMilliseconds(    1_000, true)).toBe("1.0s");
+        expect(formatMilliseconds(   60_000, true)).toBe("1m 0s");
+        expect(formatMilliseconds( 3600_000, true)).toBe("1h 0m");
+        expect(formatMilliseconds(86400_000, true)).toBe("1d 0h");
     });
 });
 
-describe("separateMillisecondsIntoMultipleUnits", () => {
+describe("separateMillisecondsIntoMagnitudes", () => {
     // Concise alias for function-under-test.
-    const fn = separateMillisecondsIntoMultipleUnits;
+    const fn = separateMillisecondsIntoMagnitudes;
 
     it("handles 0 milliseconds", () => {
         expect(fn(0)).toMatchObject({
@@ -53,11 +53,11 @@ describe("separateMillisecondsIntoMultipleUnits", () => {
     });
 });
 
-describe("formatMultipleUnits", () => {
+describe("formatMagnitudesUsingMultipleUnits", () => {
     let magnitudes;
 
     // Concise alias for function-under-test.
-    const fn = formatMultipleUnits;
+    const fn = formatMagnitudesUsingMultipleUnits;
 
     it("represents durations (T < 1 second) using seconds (fractional)", () => {
         magnitudes = { days: 0, hours: 0, minutes: 0, seconds: 0, milliseconds: 0 };
@@ -171,4 +171,24 @@ describe("formatMultipleUnits", () => {
         magnitudes = { days: 0, hours: 0, minutes: 0, seconds: 0, milliseconds: 1 };
         expect(fn(magnitudes)).toBe("0.0 seconds");
     });
+
+    it("uses abbreviated unit names when caller requests it", () => {
+        magnitudes = { days: 1, hours: 0, minutes: 0, seconds: 0, milliseconds: 0 };
+        expect(fn(magnitudes, true)).toBe("1d 0h");
+
+        magnitudes = { days: 1, hours: 1, minutes: 0, seconds: 0, milliseconds: 0 };
+        expect(fn(magnitudes, true)).toBe("1d 1h");
+
+        magnitudes = { days: 0, hours: 0, minutes: 1, seconds: 0, milliseconds: 0 };
+        expect(fn(magnitudes, true)).toBe("1m 0s");
+
+        magnitudes = { days: 0, hours: 0, minutes: 1, seconds: 1, milliseconds: 0 };
+        expect(fn(magnitudes, true)).toBe("1m 1s");
+
+        magnitudes = { days: 0, hours: 0, minutes: 0, seconds: 1, milliseconds: 0 };
+        expect(fn(magnitudes, true)).toBe("1.0s");
+
+        magnitudes = { days: 0, hours: 0, minutes: 0, seconds: 0, milliseconds: 1 };
+        expect(fn(magnitudes, true)).toBe("0.0s");
+    });    
 });

--- a/src/tests/uiutil.test.js
+++ b/src/tests/uiutil.test.js
@@ -1,0 +1,35 @@
+import { formatMilliseconds } from "../uiutil";
+
+describe("formatMilliseconds", () => {
+    it("uses 'XXs' format by default", () => {
+        expect(formatMilliseconds(        1)).toBe("0s");     // 1ms
+        expect(formatMilliseconds(    1_000)).toBe("1s");     // 1s
+        expect(formatMilliseconds(   60_000)).toBe("60s");    // 1m
+        expect(formatMilliseconds( 3600_000)).toBe("3600s");  // 1h
+        expect(formatMilliseconds(86400_000)).toBe("86400s"); // 1d
+    });
+
+    it("uses humanized format if flag is set", () => {
+        // Exactly 1ms, 1s, 1m, 1h, 1d:
+        expect(formatMilliseconds(        1, true)).toBe("a few seconds");
+        expect(formatMilliseconds(    1_000, true)).toBe("a few seconds");
+        expect(formatMilliseconds(   60_000, true)).toBe("a minute");
+        expect(formatMilliseconds( 3600_000, true)).toBe("an hour");
+        expect(formatMilliseconds(86400_000, true)).toBe("a day");
+
+        // Edge cases (and some non-edge cases):
+        expect(formatMilliseconds(        1, true)).toBe("a few seconds");
+        expect(formatMilliseconds(   44_499, true)).toBe("a few seconds");
+        expect(formatMilliseconds(   44_500, true)).toBe("a minute");
+        expect(formatMilliseconds(   89_999, true)).toBe("a minute");
+        expect(formatMilliseconds(   90_000, true)).toBe("2 minutes");
+        expect(formatMilliseconds(  149_999, true)).toBe("2 minutes");
+        expect(formatMilliseconds(  150_000, true)).toBe("3 minutes");
+        expect(formatMilliseconds( 1800_000, true)).toBe("30 minutes");
+        expect(formatMilliseconds( 2400_000, true)).toBe("40 minutes");
+        expect(formatMilliseconds( 2640_000, true)).toBe("44 minutes");
+        expect(formatMilliseconds( 2669_999, true)).toBe("44 minutes");
+        expect(formatMilliseconds( 2670_000, true)).toBe("an hour"); // 44m 30s
+        expect(formatMilliseconds( 3200_000, true)).toBe("an hour");
+    });
+});

--- a/src/tests/uiutil.test.js
+++ b/src/tests/uiutil.test.js
@@ -12,9 +12,9 @@ describe("formatMilliseconds", () => {
     it("uses humanized format if flag is set", () => {
         expect(formatMilliseconds(        1, true)).toBe("0.0 seconds");
         expect(formatMilliseconds(    1_000, true)).toBe("1.0 seconds");
-        expect(formatMilliseconds(   60_000, true)).toBe("1 minutes 0 seconds");
-        expect(formatMilliseconds( 3600_000, true)).toBe("1 hours 0 minutes");
-        expect(formatMilliseconds(86400_000, true)).toBe("1 days 0 hours");
+        expect(formatMilliseconds(   60_000, true)).toBe("1 minute 0 seconds");
+        expect(formatMilliseconds( 3600_000, true)).toBe("1 hour 0 minutes");
+        expect(formatMilliseconds(86400_000, true)).toBe("1 day 0 hours");
     });
 });
 
@@ -109,13 +109,13 @@ describe("formatMultipleUnits", () => {
 
     it("represents durations (1 minute <= T < 1 hour) using minutes (integer) and seconds (integer)", () => {
         magnitudes = { days: 0, hours: 0, minutes: 1, seconds: 0, milliseconds: 0 };
-        expect(fn(magnitudes)).toBe("1 minutes 0 seconds");
+        expect(fn(magnitudes)).toBe("1 minute 0 seconds");
 
         magnitudes = { days: 0, hours: 0, minutes: 1, seconds: 0, milliseconds: 999 };
-        expect(fn(magnitudes)).toBe("1 minutes 0 seconds");
+        expect(fn(magnitudes)).toBe("1 minute 0 seconds");
 
         magnitudes = { days: 0, hours: 0, minutes: 1, seconds: 1, milliseconds: 0 };
-        expect(fn(magnitudes)).toBe("1 minutes 1 seconds");
+        expect(fn(magnitudes)).toBe("1 minute 1 second");
 
         magnitudes = { days: 0, hours: 0, minutes: 59, seconds: 59, milliseconds: 999 };
         expect(fn(magnitudes)).toBe("59 minutes 59 seconds");
@@ -123,13 +123,13 @@ describe("formatMultipleUnits", () => {
 
     it("represents durations (1 hour <= T < 1 day) using hours (integer) and minutes (integer)", () => {
         magnitudes = { days: 0, hours: 1, minutes: 0, seconds: 0, milliseconds: 0 };
-        expect(fn(magnitudes)).toBe("1 hours 0 minutes");
+        expect(fn(magnitudes)).toBe("1 hour 0 minutes");
 
         magnitudes = { days: 0, hours: 1, minutes: 0, seconds: 59, milliseconds: 999 };
-        expect(fn(magnitudes)).toBe("1 hours 0 minutes");
+        expect(fn(magnitudes)).toBe("1 hour 0 minutes");
 
         magnitudes = { days: 0, hours: 1, minutes: 1, seconds: 0, milliseconds: 0 };
-        expect(fn(magnitudes)).toBe("1 hours 1 minutes");
+        expect(fn(magnitudes)).toBe("1 hour 1 minute");
 
         magnitudes = { days: 0, hours: 23, minutes: 59, seconds: 59, milliseconds: 999 };
         expect(fn(magnitudes)).toBe("23 hours 59 minutes");
@@ -137,18 +137,38 @@ describe("formatMultipleUnits", () => {
 
     it("represents durations (T >= 1 day) using days (integer) and hours (integer)", () => {
         magnitudes = { days: 1, hours: 0, minutes: 0, seconds: 0, milliseconds: 0 };
-        expect(fn(magnitudes)).toBe("1 days 0 hours");
+        expect(fn(magnitudes)).toBe("1 day 0 hours");
 
         magnitudes = { days: 1, hours: 0, minutes: 59, seconds: 59, milliseconds: 999 };
-        expect(fn(magnitudes)).toBe("1 days 0 hours");
+        expect(fn(magnitudes)).toBe("1 day 0 hours");
 
         magnitudes = { days: 1, hours: 1, minutes: 0, seconds: 0, milliseconds: 0 };
-        expect(fn(magnitudes)).toBe("1 days 1 hours");
+        expect(fn(magnitudes)).toBe("1 day 1 hour");
 
         magnitudes = { days: 1, hours: 23, minutes: 59, seconds: 59, milliseconds: 999 };
-        expect(fn(magnitudes)).toBe("1 days 23 hours");
+        expect(fn(magnitudes)).toBe("1 day 23 hours");
 
         magnitudes = { days: 7, hours: 0, minutes: 0, seconds: 0, milliseconds: 0 };
         expect(fn(magnitudes)).toBe("7 days 0 hours"); // even a week uses units of days
+    });
+
+    it("uses correct singular vs. plural unit names", () => {
+        magnitudes = { days: 1, hours: 0, minutes: 0, seconds: 0, milliseconds: 0 };
+        expect(fn(magnitudes)).toBe("1 day 0 hours");
+
+        magnitudes = { days: 1, hours: 1, minutes: 0, seconds: 0, milliseconds: 0 };
+        expect(fn(magnitudes)).toBe("1 day 1 hour");
+
+        magnitudes = { days: 0, hours: 0, minutes: 1, seconds: 0, milliseconds: 0 };
+        expect(fn(magnitudes)).toBe("1 minute 0 seconds");
+
+        magnitudes = { days: 0, hours: 0, minutes: 1, seconds: 1, milliseconds: 0 };
+        expect(fn(magnitudes)).toBe("1 minute 1 second");
+
+        magnitudes = { days: 0, hours: 0, minutes: 0, seconds: 1, milliseconds: 0 };
+        expect(fn(magnitudes)).toBe("1.0 seconds"); // plural, since it includes decimal places
+
+        magnitudes = { days: 0, hours: 0, minutes: 0, seconds: 0, milliseconds: 1 };
+        expect(fn(magnitudes)).toBe("0.0 seconds");
     });
 });

--- a/src/tests/uiutil.test.js
+++ b/src/tests/uiutil.test.js
@@ -10,8 +10,8 @@ describe("formatMilliseconds", () => {
     });
 
     it("uses humanized format if flag is set", () => {
-        expect(formatMilliseconds(        1, true)).toBe("0.001 seconds");
-        expect(formatMilliseconds(    1_000, true)).toBe("1 seconds");
+        expect(formatMilliseconds(        1, true)).toBe("0.0 seconds");
+        expect(formatMilliseconds(    1_000, true)).toBe("1.0 seconds");
         expect(formatMilliseconds(   60_000, true)).toBe("1 minutes 0 seconds");
         expect(formatMilliseconds( 3600_000, true)).toBe("1 hours 0 minutes");
         expect(formatMilliseconds(86400_000, true)).toBe("1 days 0 hours");
@@ -61,36 +61,36 @@ describe("formatMultipleUnits", () => {
 
     it("represents durations (T < 1 second) using seconds (fractional)", () => {
         magnitudes = { days: 0, hours: 0, minutes: 0, seconds: 0, milliseconds: 0 };
-        expect(fn(magnitudes)).toBe("0 seconds");
+        expect(fn(magnitudes)).toBe("0.0 seconds");
 
         magnitudes = { days: 0, hours: 0, minutes: 0, seconds: 0, milliseconds: 1 };
-        expect(fn(magnitudes)).toBe("0.001 seconds");
+        expect(fn(magnitudes)).toBe("0.0 seconds");
 
         magnitudes = { days: 0, hours: 0, minutes: 0, seconds: 0, milliseconds: 10 };
-        expect(fn(magnitudes)).toBe("0.01 seconds");
+        expect(fn(magnitudes)).toBe("0.0 seconds");
 
         magnitudes = { days: 0, hours: 0, minutes: 0, seconds: 0, milliseconds: 100 };
         expect(fn(magnitudes)).toBe("0.1 seconds");
 
         magnitudes = { days: 0, hours: 0, minutes: 0, seconds: 0, milliseconds: 999 };
-        expect(fn(magnitudes)).toBe("0.999 seconds");
+        expect(fn(magnitudes)).toBe("1.0 seconds"); // input was < 1, but rounded value is 1
     });
 
     it("represents durations (1 second <= T < 10 seconds) using seconds (fractional)", () => {
         magnitudes = { days: 0, hours: 0, minutes: 0, seconds: 1, milliseconds: 0 };
-        expect(fn(magnitudes)).toBe("1 seconds");
+        expect(fn(magnitudes)).toBe("1.0 seconds");
 
         magnitudes = { days: 0, hours: 0, minutes: 0, seconds: 1, milliseconds: 1 };
-        expect(fn(magnitudes)).toBe("1.001 seconds");
+        expect(fn(magnitudes)).toBe("1.0 seconds");
 
         magnitudes = { days: 0, hours: 0, minutes: 0, seconds: 1, milliseconds: 10 };
-        expect(fn(magnitudes)).toBe("1.01 seconds");
+        expect(fn(magnitudes)).toBe("1.0 seconds");
 
         magnitudes = { days: 0, hours: 0, minutes: 0, seconds: 1, milliseconds: 100 };
         expect(fn(magnitudes)).toBe("1.1 seconds");
 
         magnitudes = { days: 0, hours: 0, minutes: 0, seconds: 9, milliseconds: 999 };
-        expect(fn(magnitudes)).toBe("9.999 seconds");
+        expect(fn(magnitudes)).toBe("10.0 seconds"); // input was < 10, but rounded value is 10
     });
 
     it("represents durations (10 seconds <= T < 1 minute) using seconds (integer)", () => {
@@ -149,6 +149,6 @@ describe("formatMultipleUnits", () => {
         expect(fn(magnitudes)).toBe("1 days 23 hours");
 
         magnitudes = { days: 7, hours: 0, minutes: 0, seconds: 0, milliseconds: 0 };
-        expect(fn(magnitudes)).toBe("7 days 0 hours"); // no special treatment for a week
+        expect(fn(magnitudes)).toBe("7 days 0 hours"); // even a week uses units of days
     });
 });

--- a/src/uiutil.js
+++ b/src/uiutil.js
@@ -1,6 +1,7 @@
 import { faBan, faCheck, faChevronLeft, faCopy, faExclamationCircle, faExclamationTriangle, faFolderOpen, faTerminal, faWindowClose } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import axios from 'axios';
+import moment from 'moment';
 import React, { useState } from 'react';
 import Button from 'react-bootstrap/Button';
 import Form from 'react-bootstrap/Form';
@@ -109,11 +110,39 @@ export function redirectIfNotConnected(e) {
     }
 }
 
-export function formatMilliseconds(ms) {
+/**
+ * Convert a number of milliseconds into a humanized string.
+ * (e.g. 3000 --> "a few seconds")
+ *
+ * @see https://momentjs.com/docs/#/durations/locale/
+ * 
+ * @param {number} ms - The number of milliseconds (i.e. some duration).
+ * @param {string} locale - The moment.js locale you want to use.
+ * @returns {string} The humanized string.
+ */
+ export function humanizeMilliseconds(ms, locale = "en") {
+    const duration = moment.duration(ms, "milliseconds");
+    const humanizedStr = duration.locale(locale).humanize();
+    return humanizedStr;
+}
+
+/**
+ * Convert a number of milliseconds into a formatted string, either
+ * humanized (e.g. "a few seconds") or in units of seconds (e.g. "3.2s").
+ * 
+ * @param {number} ms - The number of milliseconds (i.e. some duration).
+ * @param {boolean} humanize - Whether you want to humanize the string. 
+ * @returns {string} The formatted string.
+ */
+export function formatMilliseconds(ms, humanize = false) {
+    if (humanize) {
+        return humanizeMilliseconds(ms);
+    }
+
     return Math.round(ms / 100.0) / 10.0 + "s"
 }
 
-export function formatDuration(from, to) {
+export function formatDuration(from, to, humanize = false) {
     if (!from) {
         return "";
     }
@@ -127,12 +156,13 @@ export function formatDuration(from, to) {
         return formatMilliseconds(ms)
     }
 
-    return formatMilliseconds(new Date(to).valueOf() - new Date(from).valueOf());
+    return formatMilliseconds(new Date(to).valueOf() - new Date(from).valueOf(), humanize);
 }
 
 export function taskStatusSymbol(task) {
     const st = task.status;
     const dur = formatDuration(task.startTime, task.endTime);
+    const humanizedDur = formatDuration(task.startTime, task.endTime, true);
 
     switch (st) {
         case "RUNNING":
@@ -143,13 +173,13 @@ export function taskStatusSymbol(task) {
             </>;
 
         case "SUCCESS":
-            return <p><FontAwesomeIcon icon={faCheck} color="green" /> Finished in {dur}</p>;
+            return <p title={dur}><FontAwesomeIcon icon={faCheck} color="green" /> Finished in {humanizedDur}</p>;
 
         case "FAILED":
-            return <p><FontAwesomeIcon icon={faExclamationCircle} color="red" /> Failed after {dur}</p>;
+            return <p title={dur}><FontAwesomeIcon icon={faExclamationCircle} color="red" /> Failed after {humanizedDur}</p>;
 
         case "CANCELED":
-            return <p><FontAwesomeIcon icon={faBan} /> Canceled after {dur}</p>;
+            return <p title={dur}><FontAwesomeIcon icon={faBan} /> Canceled after {humanizedDur}</p>;
 
         default:
             return st;

--- a/src/uiutil.js
+++ b/src/uiutil.js
@@ -117,12 +117,11 @@ export function redirectIfNotConnected(e) {
  * @see https://momentjs.com/docs/#/durations/locale/
  * 
  * @param {number} ms - The number of milliseconds (i.e. some duration).
- * @param {string} locale - The moment.js locale you want to use.
  * @returns {string} The humanized string.
  */
- export function humanizeMilliseconds(ms, locale = "en") {
+ export function humanizeMilliseconds(ms) {
     const duration = moment.duration(ms, "milliseconds");
-    const humanizedStr = duration.locale(locale).humanize();
+    const humanizedStr = duration.humanize();
     return humanizedStr;
 }
 

--- a/src/uiutil.js
+++ b/src/uiutil.js
@@ -127,7 +127,7 @@ export function humanizeMilliseconds(ms) {
  * when combined together, equal the original duration (minus any partial
  * milliseconds, if the original duration included any partial milliseconds).
  * 
- * e.g. 100000123.999 --> 1 days 3 hours 46 minutes 40 seconds 123 milliseconds
+ * e.g. 100000123.999 --> 1 day 3 hours 46 minutes 40 seconds 123 milliseconds
  * 
  * @param {ms} ms - The original duration (i.e. some number of milliseconds).
  * @returns {object} Multi-unit representation of the original duration.
@@ -167,16 +167,26 @@ export function separateMillisecondsIntoMultipleUnits(ms) {
 export function formatMultipleUnits(magnitudes) {
     let str;
 
+    // Determine whether we will use the singular or plural form of each unit name.
+    const units = {
+        days: magnitudes.days === 1 ? "day" : "days",
+        hours: magnitudes.hours === 1 ? "hour" : "hours",
+        minutes: magnitudes.minutes === 1 ? "minute" : "minutes",
+        seconds: magnitudes.seconds === 1 ? "second" : "seconds",
+        milliseconds: magnitudes.milliseconds === 1 ? "millisecond" : "milliseconds",
+    };
+
+    // Format the duration, depending upon the magnitudes of its parts.
     if (magnitudes.days > 0) {
-        str = `${magnitudes.days} days ${magnitudes.hours} hours`;
+        str = `${magnitudes.days} ${units.days} ${magnitudes.hours} ${units.hours}`;
     } else if (magnitudes.hours > 0) {
-        str = `${magnitudes.hours} hours ${magnitudes.minutes} minutes`;
+        str = `${magnitudes.hours} ${units.hours} ${magnitudes.minutes} ${units.minutes}`;
     } else if (magnitudes.minutes > 0) {
-        str = `${magnitudes.minutes} minutes ${magnitudes.seconds} seconds`;
+        str = `${magnitudes.minutes} ${units.minutes} ${magnitudes.seconds} ${units.seconds}`;
     } else if (magnitudes.seconds >= 10) {
-        str = `${magnitudes.seconds} seconds`;
+        str = `${magnitudes.seconds} ${units.seconds}`;
     } else {
-        // Combine the magnitudes into the equivalent number of milliseconds.
+        // Combine the magnitudes into the equivalent total number of milliseconds.
         const ms = (
             magnitudes.milliseconds +
             magnitudes.seconds * 1000 +
@@ -186,6 +196,8 @@ export function formatMultipleUnits(magnitudes) {
         );
 
         // Convert into seconds and round to the nearest tenth of a second.
+        // Use the plural form of the unit name, since the number will have
+        // a digit after a decimal point (e.g. "1.0 seconds").
         const seconds = ms / 1000;
         str = `${seconds.toFixed(1)} seconds`;
     }
@@ -195,10 +207,10 @@ export function formatMultipleUnits(magnitudes) {
 
 /**
  * Convert a number of milliseconds into a formatted string, either
- * humanized (e.g. "a few seconds") or in units of seconds (e.g. "3.2s").
+ * humanized (e.g. "1 minute 5 seconds") or in units of seconds (e.g. "65.0s").
  * 
  * @param {number} ms - The number of milliseconds (i.e. some duration).
- * @param {boolean} humanize - Whether you want to humanize the string. 
+ * @param {boolean} humanize - Whether you want to humanize the string.
  * @returns {string} The formatted string.
  */
 export function formatMilliseconds(ms, humanize = false) {

--- a/src/uiutil.js
+++ b/src/uiutil.js
@@ -114,7 +114,7 @@ export function redirectIfNotConnected(e) {
  * Convert a number of milliseconds into a humanized string.
  * (e.g. 3000 --> "a few seconds")
  *
- * @see https://momentjs.com/docs/#/durations/locale/
+ * @see https://momentjs.com/docs/#/durations/humanize/
  * 
  * @param {number} ms - The number of milliseconds (i.e. some duration).
  * @returns {string} The humanized string.

--- a/src/uiutil.js
+++ b/src/uiutil.js
@@ -184,9 +184,12 @@ export function formatMultipleUnits(magnitudes) {
             magnitudes.hours * 60 * 60 * 1000 +
             magnitudes.days * 24 * 60 * 60 * 1000
         );
-        str = `${ms / 1000} seconds`;
+
+        // Convert into seconds and round to the nearest tenth of a second.
+        const seconds = ms / 1000;
+        str = `${seconds.toFixed(1)} seconds`;
     }
-    
+
     return str;
 }
 

--- a/src/uiutil.js
+++ b/src/uiutil.js
@@ -1,7 +1,6 @@
 import { faBan, faCheck, faChevronLeft, faCopy, faExclamationCircle, faExclamationTriangle, faFolderOpen, faTerminal, faWindowClose } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import axios from 'axios';
-import moment from 'moment';
 import React, { useState } from 'react';
 import Button from 'react-bootstrap/Button';
 import Form from 'react-bootstrap/Form';


### PR DESCRIPTION
### Changes

- The durations in the "Status" column of the table on the "Tasks" page now appear as humanized strings (e.g. "a few seconds") instead of as a number of seconds (e.g. "2.7s"). The original "seconds" string is still accessible by hovering the mouse cursor over the humanized string.
- I widened the "Status" column of the same table so its contents fit on a single line. I also narrowed the "Start Time" column by the same amount (its contents still fit on a single line), so the total table width has not changed.

### Screenshots

#### Before

![image](https://user-images.githubusercontent.com/7143133/174391213-e20d40f9-10ef-45e2-a361-143a29a68203.png)

#### After

![image](https://user-images.githubusercontent.com/7143133/174391362-b5c0fe21-f158-40ce-a5df-0779485113f8.png)

Fixes: https://github.com/kopia/kopia/issues/2055