### PR TITLE
Display repository description on every page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -116,6 +116,10 @@ export default class App extends Component {
           </Navbar>
 
           <Container fluid>
+            <NavLink to="/repo" style={{ color: "inherit", textDecoration: "inherit" }}>
+              <h3 className="mb-4">{this.repoDescription}</h3>
+            </NavLink>
+
             <Switch>
               <Route path="/snapshots/new" component={NewSnapshot} />
               <Route path="/snapshots/single-source/" component={SnapshotsTable} />

--- a/src/AppContext.js
+++ b/src/AppContext.js
@@ -1,4 +1,8 @@
 import React from 'react';
 
-export const AppContext = React.createContext({});
+const defaultValue = {
+    repoDescription: "",
+};
+
+export const AppContext = React.createContext(defaultValue);
 

--- a/src/RepoStatus.js
+++ b/src/RepoStatus.js
@@ -11,7 +11,7 @@ import { handleChange } from './forms';
 import { SetupRepository } from './SetupRepository';
 import { cancelTask, CLIEquivalent } from './uiutil';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faChevronCircleDown, faChevronCircleUp, faWindowClose } from '@fortawesome/free-solid-svg-icons';
+import { faCheck, faChevronCircleDown, faChevronCircleUp, faWindowClose } from '@fortawesome/free-solid-svg-icons';
 import { TaskLogs } from './TaskLogs';
 import { AppContext } from './AppContext';
 
@@ -62,6 +62,9 @@ export class RepoStatus extends Component {
                     isLoading: false,
                 });
 
+                // Update the app context to reflect the successfully-loaded description.
+                this.context.repoDescription = result.data.description;
+
                 if (result.data.initTaskID) {
                     window.setTimeout(() => {
                         this.fetchStatusWithoutSpinner();
@@ -100,6 +103,9 @@ export class RepoStatus extends Component {
         axios.post('/api/v1/repo/description', {
             "description": this.state.status.description,
         }).then(result => {
+            // Update the app context to reflect the successfully-saved description.
+            this.context.repoDescription = this.state.status.description;
+
             this.setState({
                 isLoading: false,
             });
@@ -133,7 +139,10 @@ export class RepoStatus extends Component {
 
         if (this.state.status.connected) {
             return <>
-                <h3>Connected To Repository</h3>
+                <p className="text-success mb-1">
+                    <FontAwesomeIcon icon={faCheck} style={{ marginRight: 4 }} />
+                    <span>Connected To Repository</span>
+                </p>
                 <Form onSubmit={this.updateDescription}>
                     <Row>
                         <Form.Group as={Col}>


### PR DESCRIPTION
### Changes

- The repository description (e.g. "My Repository") now appears at the top of every page, just below the top navigation bar
- The repository description is a hyperlink (unstyled) leading to the "Repository" tab
- The "Connected To Repository" heading is no longer a heading, and, instead, appears as green text with a checkmark

### Known issues

The client only loads the repository description when the user goes to the "Repository" tab, so this newly-added repository description header will not be visible until that has happened. One way this could be resolved is by loading the repository "status" (i.e. details) at the app level, when the app first loads (rather than only when the "Repository" tab is first visited).

### Screenshots

#### Before

The "Repository" tab:

![image](https://user-images.githubusercontent.com/7143133/174403456-42c1a531-469f-4227-8b93-76c8d3f9fcce.png)

A tab other than the "Repository" tab:

![image](https://user-images.githubusercontent.com/7143133/174403303-d3ddc3b7-c8c5-40a6-8dcc-d47830dc8bfd.png)

#### After

The "Repository" tab:

![image](https://user-images.githubusercontent.com/7143133/174403431-e2fa9b07-375b-4f04-9a1b-e806ad4c09ff.png)

A tab other than the "Repository" tab:

![image](https://user-images.githubusercontent.com/7143133/174403223-e023ebf1-336c-4027-9849-a08e13c647a2.png)

### Fixes

Fixes https://github.com/kopia/kopia/issues/2051