### PR TITLE
Removing text from SetupGCS.js, SetupS3.js, and SetupRclone.js

### DIFF
--- a/src/SetupGCS.js
+++ b/src/SetupGCS.js
@@ -20,12 +20,6 @@ export class SetupGCS extends Component {
     render() {
         return <>
             <Row>
-                To use Google Cloud Storage with Kopia, you need a JSON credentials file that gives Kopia access to upload to your Google Cloud Storage account. The easiest way to generate such a file is by using a Google Cloud Storage Service account. If you have trouble generating this credentials file, you can alternatively connect to Google Cloud Storage through Kopia's Amazon S3 option, because Google Cloud Storage is S3 compatible. See <a href="https://kopia.io/docs/repositories/#google-cloud-storage" target="_blank" rel="noreferrer">Kopia help docs</a> for more information on both these options. 
-            </Row>
-            <Row>
-                &nbsp;
-            </Row>
-            <Row>
                 {RequiredField(this, "GCS Bucket", "bucket", { autoFocus: true, placeholder: "enter bucket name" })}
                 {OptionalField(this, "Object Name Prefix", "prefix", { placeholder: "enter object name prefix or leave empty", type: "password" })}
             </Row>

--- a/src/SetupRclone.js
+++ b/src/SetupRclone.js
@@ -19,15 +19,6 @@ export class SetupRclone extends Component {
     render() {
         return <>
             <Row>
-                Rclone is a third-party program that allows you to manage files on various different storage providers. Kopia allows you to backup to all the storage providers that Rclone supports, but please note that Rclone support is experimental. In theory, all Rclone-supported storage providers should work with Kopia. However, in practice, only OneDrive, Google Drive, and Dropbox have been tested to work through Rclone with Kopia.
-            </Row>
-            <Row>
-                You need to do the following before you try to connect to a storage provider through Rclone with Kopia: (1) download Rclone from <a href="https://rclone.org/" target="_blank" rel="noreferrer">https://rclone.org/</a> and (2) configure Rclone to setup a remote to the storage provider you want to use Kopia with: see <a href="https://rclone.org/docs/" target="_blank" rel="noreferrer">https://rclone.org/docs/</a> for directions. Once you have configured a Rclone remote, you have to create a Kopia repository for that Rclone remote by entering below (i) the path to the Rclone remote and (ii) the path to the Rclone executable you have on your machine. Once you have setup this repository in Kopia, Kopia will automatically launch Rclone when Rclone is needed; you do not need to do manage Rclone except you need to make sure to keep Rclone up-to-date -- see <a href="https://rclone.org/commands/rclone_selfupdate/" target="_blank" rel="noreferrer">https://rclone.org/commands/rclone_selfupdate/</a> for directions.
-            </Row>
-            <Row>
-                &nbsp;
-            </Row>
-            <Row>
                 {RequiredField(this, "Rclone Remote Path", "remotePath", { autoFocus: true, placeholder: "enter <name-of-rclone-remote>:<path>" })}
             </Row>
             <Row>

--- a/src/SetupS3.js
+++ b/src/SetupS3.js
@@ -21,12 +21,6 @@ export class SetupS3 extends Component {
     render() {
         return <>
             <Row>
-                All S3-compatible storage providers are supported by Kopia, including but not limited to Amazon S3, Amazon Lightsail, Wasabi, IDrive E2, MinIO, Backblaze B2, Oracle Cloud Infrastructure, Google Cloud Storage, and DigitalOcean Spaces.
-            </Row>
-            <Row>
-                &nbsp;
-            </Row>
-            <Row>
                 {RequiredField(this, "Bucket", "bucket", { autoFocus: true, placeholder: "enter bucket name" })}
                 {RequiredField(this, "Server Endpoint", "endpoint", { placeholder: "enter server address (e.g., s3.amazonaws.com)" })}
                 {OptionalField(this, "Override Region", "region", { placeholder: "enter specific region (e.g., us-west-1) or leave empty" })}


### PR DESCRIPTION
I submitted PRs to add some text blurbs to these files. After using the latest KopiaUI build, I see that the texts are just very poorly formatted and generally look out of place. Rather than put these text in KopiaUI, I will add them to the help docs instead.