### PR TITLE
"Kopia UI" to "KopiaUI"

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -9,7 +9,7 @@
   <meta name="color-scheme" content="light dark">
   <link rel="apple-touch-icon" href="logo192.png" />
   <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-  <title>Kopia UI</title>
+  <title>KopiaUI</title>
 </head>
 
 <body>


### PR DESCRIPTION
Just removing the extra space

Related: https://github.com/kopia/kopia/pull/2140