### PR TITLE
fixed log detail color in dark mode

### DIFF
--- a/src/TaskLogs.js
+++ b/src/TaskLogs.js
@@ -87,7 +87,7 @@ export class TaskLogs extends Component {
 
         const p = JSON.stringify(parametersOnly);
         if (p !== "{}") {
-            return <span className="log-parameter">{p}</span>;
+            return <code>{p}</code>;
         }
 
         return "";


### PR DESCRIPTION
Fixes kopia/kopia#2143

Switched to simple `<code>` instead of custom style:

Light mode:

<img width="609" alt="image" src="https://user-images.githubusercontent.com/249880/177583025-a21b0a5a-5017-427b-a301-6bc508c66f8e.png">

Dark mode:

<img width="609" alt="image" src="https://user-images.githubusercontent.com/249880/177583067-0d470381-f99f-4023-8f00-a683b99ff9ac.png">
