### PR TITLE
Fix npm start not working with node 18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@fortawesome/free-solid-svg-icons": "^6.1.1",
         "@fortawesome/react-fontawesome": "^0.2.0",
         "bootstrap-dark-5": "^1.1.3",
+        "http-proxy-middleware": "^2.0.6",
         "moment": "^2.29.3",
         "react": "^18.2.0",
         "react-bootstrap": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@fortawesome/free-solid-svg-icons": "^6.1.1",
     "@fortawesome/react-fontawesome": "^0.2.0",
     "bootstrap-dark-5": "^1.1.3",
+    "http-proxy-middleware": "^2.0.6",
     "moment": "^2.29.3",
     "react": "^18.2.0",
     "react-bootstrap": "^2.1.2",
@@ -23,7 +24,6 @@
   "eslintConfig": {
     "extends": "react-app"
   },
-  "proxy": "http://127.0.0.1:51515",
   "browserslist": {
     "production": [
       ">0.2%",

--- a/src/setupProxy.js
+++ b/src/setupProxy.js
@@ -1,0 +1,11 @@
+const { createProxyMiddleware } = require('http-proxy-middleware');
+
+module.exports = function(app) {
+  app.use(
+    '/api',
+    createProxyMiddleware({
+      target: 'http://127.0.0.1:51515',
+      changeOrigin: true,
+    })
+  );
+};


### PR DESCRIPTION
This PR uses `http-proxy-middleware` to workaround an error with the `proxy` config in `package.json` when using node 18.

Got the workaround from https://stackoverflow.com/a/70413065