### PR TITLE
fix: back-button within SetupRepository

### DIFF
--- a/src/SetupRepository.jsx
+++ b/src/SetupRepository.jsx
@@ -440,7 +440,7 @@ export class SetupRepository extends Component {
             </Collapse>
             {this.connectionErrorInfo()}
             <hr />
-            <Button data-testid='back-button' variant="secondary" onClick={() => this.setState({ storageVerified: false })}>Back</Button>
+            <Button data-testid='back-button' variant="secondary" onClick={() => this.setState({ providerSettings: {}, storageVerified: false })}>Back</Button>
             &nbsp;
             <Button variant="success" type="submit" data-testid="submit-button">Create Repository</Button>
             {this.loadingSpinner()}
@@ -493,7 +493,7 @@ export class SetupRepository extends Component {
             </Collapse>
             {this.connectionErrorInfo()}
             <hr />
-            <Button data-testid='back-button' variant="secondary" onClick={() => this.setState({ storageVerified: false })}>Back</Button>
+            <Button data-testid='back-button' variant="secondary" onClick={() => this.setState({ providerSettings: {}, storageVerified: false })}>Back</Button>
             &nbsp;
             <Button variant="success" type="submit" data-testid="submit-button">Connect To Repository</Button>
             {this.loadingSpinner()}


### PR DESCRIPTION
The back button wasn`t behaving correctly when setting up a repository. The user could not navigate back once the path or url was given. 

The PR adds "providerSettings: {}" to the setState method.
 
I've attached to examples - one before and one after the fix. However, I am not very good at react js. Feedback is welcomed. 

#### Before the fix:

https://user-images.githubusercontent.com/37236531/227763069-b7e92308-c82d-4685-8b8c-f755801eace4.mp4


#### After the fix:

https://user-images.githubusercontent.com/37236531/227763083-0dd7d8e5-4520-4090-8c4b-a205e1a9a1e7.mp4


Cheers, 