### PR TITLE
fix: Policy editor for "Cache Miss" actually modifies/reads "cacheHit" property

### DIFF
--- a/src/PolicyEditor/index.jsx
+++ b/src/PolicyEditor/index.jsx
@@ -525,7 +525,7 @@ export class PolicyEditor extends Component {
                             <Row>
                                 <LabelColumn name="Cache Miss" help="Log verbosity when a cache cannot be used and a file must be hashed" />
                                 <WideValueColumn>
-                                    {LogDetailSelector(this, "policy.logging.entries.cacheHit")}
+                                    {LogDetailSelector(this, "policy.logging.entries.cacheMiss")}
                                 </WideValueColumn>
                                 {EffectiveValue(this, "logging.entries.cacheMiss")}
                             </Row>


### PR DESCRIPTION
Should be "cacheMiss"