### PR TITLE
do not allow overlapping update requests from setInterval

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -26,6 +26,7 @@ export default class App extends Component {
 
     this.state = {
       runningTaskCount: 0,
+      isFetching: false,
       repoDescription: "",
     };
 
@@ -65,11 +66,15 @@ export default class App extends Component {
   }
 
   fetchTaskSummary() {
+    if( ! this.state.isFetching )	  
+    {
+      this.setState({ isFetching: true });
     axios.get('/api/v1/tasks-summary').then(result => {
-      this.setState({ runningTaskCount: result.data["RUNNING"] || 0 });
+      this.setState({ isFetching: false, runningTaskCount: result.data["RUNNING"] || 0 });
     }).catch(error => {
-      this.setState({ runningTaskCount: -1 });
+      this.setState({ isFetching: false, runningTaskCount: -1 });
     });
+    }
   }
 
   componentWillUnmount() {

--- a/src/SourcesTable.jsx
+++ b/src/SourcesTable.jsx
@@ -23,6 +23,7 @@ export class SourcesTable extends Component {
         this.state = {
             sources: [],
             isLoading: false,
+            isFetching: false,
             isRefreshing: false,
             error: null,
 
@@ -51,22 +52,29 @@ export class SourcesTable extends Component {
     }
 
     fetchSourcesWithoutSpinner() {
-        axios.get('/api/v1/sources').then(result => {
+        if( ! this.state.isFetching ){
             this.setState({
-                localSourceName: result.data.localUsername + "@" + result.data.localHost,
-                multiUser: result.data.multiUser,
-                sources: result.data.sources,
-                isLoading: false,
-                isRefreshing: false,
+                isFetching: true,
             });
-        }).catch(error => {
-            redirectIfNotConnected(error);
-            this.setState({
-                error,
-                isRefreshing: false,
-                isLoading: false,
-            });
-        });
+            axios.get('/api/v1/sources').then(result => {
+                this.setState({
+                    localSourceName: result.data.localUsername + "@" + result.data.localHost,
+                    multiUser: result.data.multiUser,
+                    sources: result.data.sources,
+                    isLoading: false,
+                    isFetching: false,
+                    isRefreshing: false,
+                });
+            }).catch(error => {
+                redirectIfNotConnected(error);
+                this.setState({
+                    error,
+                    isRefreshing: false,
+                    isFetching: false,
+                    isLoading: false,
+                });
+            })
+        }
     }
 
     selectOwner(h) {


### PR DESCRIPTION
The problem is that if sync is called on the API the server may hang. Now constantly requesting task-summary and sources will lead to socket depletion. See https://github.com/kopia/kopia/issues/2453 

This rather a work around because the server should rather handle those requests in parallel.