### PR TITLE
fix(actions): actions are not saved after sanitizeActions()

### DIFF
--- a/src/PolicyEditor/index.jsx
+++ b/src/PolicyEditor/index.jsx
@@ -186,7 +186,7 @@ export class PolicyEditor extends Component {
     sanitizeActions(actions, actionTypes) {
         actionTypes.forEach(actionType => {
             if (actions[actionType]) {
-                if (actions[actionType].path === undefined || actions[actionType].path === "") {
+                if (actions[actionType].script === undefined || actions[actionType].script === "") {
                     actions[actionType] = undefined;
                 } else {
                     if (actions[actionType].timeout === undefined) {


### PR DESCRIPTION
Hi, 
this PR may fix actions not being saved in the policy editor. Debuging the policy editor indicated that the method sanitizeActions(..) checks for "path" instead of script. The policy editor, however, stores the information in "script"

" {ActionRowScript(this, "actions.afterSnapshotRoot.script", "After Snapshot", "Script to run after snapshot")}"

Therefore, all actions are set to undefined and are never saved. The issue was introduced in https://github.com/kopia/htmlui/pull/133.

This PR may fix https://github.com/kopia/kopia/issues/3046

Feedback is welcomed. 

Cheers, 