### PR TITLE
feat(ui): Allow specifying whether local or all snapshots are shown by default

### DIFF
--- a/src/SourcesTable.jsx
+++ b/src/SourcesTable.jsx
@@ -30,7 +30,7 @@ export class SourcesTable extends Component {
 
             localSourceName: "",
             multiUser: false,
-            selectedOwner: localSnapshots,
+            selectedOwner: null,
             selectedDirectory: "",
         };
 
@@ -79,9 +79,15 @@ export class SourcesTable extends Component {
     }
 
     selectOwner(h) {
+        const { setDefaultSnapshotViewAll } = this.context;
         this.setState({
             selectedOwner: h,
         });
+        if (h === localSnapshots) {
+            setDefaultSnapshotViewAll(false);
+	} else if (h === allSnapshots) {
+            setDefaultSnapshotViewAll(true);
+        }
     }
 
     sync() {
@@ -211,14 +217,16 @@ export class SourcesTable extends Component {
 
     render() {
         let { sources, isLoading, error } = this.state;
-        const { bytesStringBase2 } = this.context
+        const { bytesStringBase2, defaultSnapshotViewAll } = this.context
         if (error) {
             return <p>{error.message}</p>;
         }
         if (isLoading) {
             return <Spinner animation="border" variant="primary" />;
         }
-
+	if (this.state.selectedOwner == null) {
+	    this.setState({ selectedOwner: defaultSnapshotViewAll ? allSnapshots : localSnapshots})
+        }
         let uniqueOwners = sources.reduce((a, d) => {
             const owner = ownerName(d.source);
 

--- a/src/contexts/UIPreferencesContext.tsx
+++ b/src/contexts/UIPreferencesContext.tsx
@@ -4,7 +4,7 @@ import axios from 'axios';
 export const PAGE_SIZES = [10, 20, 30, 40, 50, 100];
 export const UIPreferencesContext = React.createContext<UIPreferences>({} as UIPreferences);
 
-const DEFAULT_PREFERENCES = { pageSize: PAGE_SIZES[0], bytesStringBase2: false, theme: getDefaultTheme() } as SerializedUIPreferences;
+const DEFAULT_PREFERENCES = { pageSize: PAGE_SIZES[0], bytesStringBase2: false, defaultSnapshotViewAll: false, theme: getDefaultTheme() } as SerializedUIPreferences;
 const PREFERENCES_URL = '/api/v1/ui-preferences';
 
 export type Theme = "light" | "dark" | "pastel" | "ocean";
@@ -14,14 +14,17 @@ export interface UIPreferences {
     get pageSize(): PageSize
     get theme(): Theme
     get bytesStringBase2(): boolean
+    get defaultSnapshotViewAll(): boolean
     setTheme: (theme: Theme) => void
     setPageSize: (pageSize: number) => void
     setByteStringBase: (bytesStringBase2: String) => void
+    setDefaultSnapshotViewAll: (defaultSnapshotView: boolean) => void
 }
 
 interface SerializedUIPreferences {
     pageSize?: number
     bytesStringBase2?: boolean
+    defaultSnapshotView?: boolean
     theme: Theme | undefined
 }
 
@@ -114,7 +117,12 @@ export function UIPreferenceProvider(props: UIPreferenceProviderProps) {
         return { ...oldPreferences, bytesStringBase2 };
     });
 
-    const providedValue = { ...preferences, setTheme, setPageSize, setByteStringBase} as UIPreferences;
+    const setDefaultSnapshotViewAll = (input: boolean) => setPreferences(oldPreferences => {
+        var defaultSnapshotViewAll = input;
+        return { ...oldPreferences, defaultSnapshotViewAll };
+    });
+
+    const providedValue = { ...preferences, setTheme, setPageSize, setByteStringBase, setDefaultSnapshotViewAll} as UIPreferences;
 
     return <UIPreferencesContext.Provider value={providedValue}>
         {props.children}


### PR DESCRIPTION
When I connect to the server http page, I prefer to see all snapshots shown by default.  every time I switch away and come back I need to reselect 'All' instead of 'Local'.  This just makes the default a preference option

Requires https://github.com/kopia/kopia/pull/3289