### PR TITLE
fix(ui): Fixed error while rendering source table

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -64,14 +64,13 @@ export default class App extends Component {
   }
 
   fetchTaskSummary() {
-    if( ! this.state.isFetching )	  
-    {
+    if (!this.state.isFetching) {
       this.setState({ isFetching: true });
-    axios.get('/api/v1/tasks-summary').then(result => {
-      this.setState({ isFetching: false, runningTaskCount: result.data["RUNNING"] || 0 });
-    }).catch(error => {
-      this.setState({ isFetching: false, runningTaskCount: -1 });
-    });
+      axios.get('/api/v1/tasks-summary').then(result => {
+        this.setState({ isFetching: false, runningTaskCount: result.data["RUNNING"] || 0 });
+      }).catch(error => {
+        this.setState({ isFetching: false, runningTaskCount: -1 });
+      });
     }
   }
 

--- a/src/SourcesTable.jsx
+++ b/src/SourcesTable.jsx
@@ -44,8 +44,7 @@ export class SourcesTable extends Component {
 
     componentDidMount() {
         const { defaultSnapshotViewAll } = this.context;
-        this.setState({ isLoading: true });
-        this.setState({ selectedOwner: defaultSnapshotViewAll ? allSnapshots : localSnapshots });
+        this.setState({ isLoading: true, selectedOwner: defaultSnapshotViewAll ? allSnapshots : localSnapshots });
         this.fetchSourcesWithoutSpinner();
         this.interval = window.setInterval(this.fetchSourcesWithoutSpinner, 3000);
     }

--- a/src/SourcesTable.jsx
+++ b/src/SourcesTable.jsx
@@ -43,7 +43,9 @@ export class SourcesTable extends Component {
     }
 
     componentDidMount() {
+        const { defaultSnapshotViewAll } = this.context;
         this.setState({ isLoading: true });
+        this.setState({ selectedOwner: defaultSnapshotViewAll ? allSnapshots : localSnapshots });
         this.fetchSourcesWithoutSpinner();
         this.interval = window.setInterval(this.fetchSourcesWithoutSpinner, 3000);
     }
@@ -53,7 +55,7 @@ export class SourcesTable extends Component {
     }
 
     fetchSourcesWithoutSpinner() {
-        if( ! this.state.isFetching ){
+        if (!this.state.isFetching) {
             this.setState({
                 isFetching: true,
             });
@@ -78,14 +80,12 @@ export class SourcesTable extends Component {
         }
     }
 
-    selectOwner(h) {
+    selectOwner(owner) {
         const { setDefaultSnapshotViewAll } = this.context;
-        this.setState({
-            selectedOwner: h,
-        });
-        if (h === localSnapshots) {
+        this.setState({ selectedOwner: owner });
+        if (owner === localSnapshots) {
             setDefaultSnapshotViewAll(false);
-	} else if (h === allSnapshots) {
+        } else if (owner === allSnapshots) {
             setDefaultSnapshotViewAll(true);
         }
     }
@@ -217,15 +217,12 @@ export class SourcesTable extends Component {
 
     render() {
         let { sources, isLoading, error } = this.state;
-        const { bytesStringBase2, defaultSnapshotViewAll } = this.context
+        const { bytesStringBase2 } = this.context
         if (error) {
             return <p>{error.message}</p>;
         }
         if (isLoading) {
             return <Spinner animation="border" variant="primary" />;
-        }
-	if (this.state.selectedOwner == null) {
-	    this.setState({ selectedOwner: defaultSnapshotViewAll ? allSnapshots : localSnapshots})
         }
         let uniqueOwners = sources.reduce((a, d) => {
             const owner = ownerName(d.source);


### PR DESCRIPTION
Hi, 

This PR is a fix of #186. Setting the state while rendering throws a JS error.
Setting the **selectedOwner** is now done after the component has been mounted. 

The rendering function then just interprets the selectedOwner. 

Feedback is welcomed. 

Cheers, 