### PR TITLE
fix(ui): Fix missing badges in policy table

### DIFF
--- a/src/PoliciesTable.jsx
+++ b/src/PoliciesTable.jsx
@@ -122,10 +122,28 @@ export class PoliciesTable extends Component {
 
     policySummary(policies) {
         let bits = [];
+        /**
+         * Check if the object is empty
+         * @param {*} obj 
+         * @returns true if the object is empty
+         */
+        function isEmptyObject(obj) {
+            return (
+                Object.getPrototypeOf(obj) === Object.prototype &&
+                Object.getOwnPropertyNames(obj).length === 0 &&
+                Object.getOwnPropertySymbols(obj).length === 0
+            );
+        }
+        /**
+         * Check if object has it's key as a property.
+         * However, if the object itself is a set of sets, it has to be checked by isEmptyObject()
+         * @param {*} obj 
+         * @returns 
+         */
         function isEmpty(obj) {
             for (var key in obj) {
                 if (obj.hasOwnProperty(key))
-                    return false;
+                    return isEmptyObject(obj[key]);
             }
             return true;
         }

--- a/src/PoliciesTable.jsx
+++ b/src/PoliciesTable.jsx
@@ -120,36 +120,20 @@ export class PoliciesTable extends Component {
         });
     }
 
-    policySummary(p) {
+    policySummary(policies) {
+        let bits = [];
         function isEmpty(obj) {
             for (var key in obj) {
                 if (obj.hasOwnProperty(key))
                     return false;
             }
-
             return true;
         }
-
-        let bits = [];
-        if (!isEmpty(p.policy.retention)) {
-            bits.push(<><Badge bg="success">retention</Badge>{' '}</>);
+        for (let pol in policies.policy) {
+            if (!isEmpty(policies.policy[pol])) {
+                bits.push(<><Badge className="policy-badge">{pol}</Badge></>);
+            }
         }
-        if (!isEmpty(p.policy.files)) {
-            bits.push(<><Badge bg="primary">files</Badge>{' '}</>);
-        }
-        if (!isEmpty(p.policy.errorHandling)) {
-            bits.push(<><Badge bg="danger">errors</Badge>{' '}</>);
-        }
-        if (!isEmpty(p.policy.compression)) {
-            bits.push(<><Badge bg="secondary">compression</Badge>{' '}</>);
-        }
-        if (!isEmpty(p.policy.scheduling)) {
-            bits.push(<><Badge bg="warning">scheduling</Badge>{' '}</>);
-        }
-        if (!isEmpty(p.policy.upload)) {
-            bits.push(<><Badge bg="info">upload</Badge>{' '}</>);
-        }
-
         return bits;
     }
 
@@ -213,16 +197,16 @@ export class PoliciesTable extends Component {
                 break;
         };
 
-        policies.sort((l,r) => {
-            const hc = compare(l.target.host,r.target.host);
+        policies.sort((l, r) => {
+            const hc = compare(l.target.host, r.target.host);
             if (hc) {
                 return hc;
             }
-            const uc = compare(l.target.userName,r.target.userName);
+            const uc = compare(l.target.userName, r.target.userName);
             if (uc) {
                 return uc;
             }
-            return compare(l.target.path,r.target.path);
+            return compare(l.target.path, r.target.path);
         });
 
 
@@ -273,8 +257,8 @@ export class PoliciesTable extends Component {
                         {(this.state.selectedOwner === localPolicies || this.state.selectedOwner === this.state.localSourceName || this.state.selectedOwner === applicablePolicies) ? <>
                             <Col>
                                 <DirectorySelector autoFocus onDirectorySelected={p => this.setState({ policyPath: p })}
-                                placeholder="enter directory to find or set policy"
-                                name="policyPath" value={this.state.policyPath} onChange={this.handleChange} />
+                                    placeholder="enter directory to find or set policy"
+                                    name="policyPath" value={this.state.policyPath} onChange={this.handleChange} />
                             </Col>
                             <Col xs="auto">
                                 <Button disabled={!this.state.policyPath} size="sm" type="submit" onClick={this.editPolicyForPath}>Set Policy</Button>

--- a/src/PoliciesTable.jsx
+++ b/src/PoliciesTable.jsx
@@ -131,7 +131,7 @@ export class PoliciesTable extends Component {
         }
         for (let pol in policies.policy) {
             if (!isEmpty(policies.policy[pol])) {
-                bits.push(<><Badge className="policy-badge">{pol}</Badge></>);
+                bits.push(<Badge className="policy-badge" key={pol}>{pol}</Badge>);
             }
         }
         return bits;

--- a/src/css/App.css
+++ b/src/css/App.css
@@ -327,6 +327,13 @@ div.tab-body {
   margin: 2px;
 }
 
+.policy-badge {
+  margin-block-start: 5px;
+  margin-right: 5px;
+  background-color: var(--color-primary) !important;
+  color: var(--text-color) !important;
+}
+
 .page-title {
   margin-left: 10px;
   font-weight: bold;


### PR DESCRIPTION
Hi, 

this PR fixes [#3343](https://github.com/kopia/kopia/issues/3343) that indicates that some policy badges are missing. These badges indicate an individual setting of policies. 

- Badges are now created in a loop, looping over all policy settings that have been changed
- Badges are now styled according to the primary color of the theme

This is how it should look:
<img width="264" alt="image" src="https://github.com/kopia/htmlui/assets/37236531/42374c31-b3f9-4213-9972-be1f035c47ea">

Feedback is welcomed. 

Cheers, 