### PR TITLE
fix(ui): Fix noParent policy not being shown

### DIFF
--- a/src/PoliciesTable.jsx
+++ b/src/PoliciesTable.jsx
@@ -145,7 +145,7 @@ export class PoliciesTable extends Component {
                 if (obj.hasOwnProperty(key))
                     return isEmptyObject(obj[key]);
             }
-            return true;
+            return isEmptyObject(obj);
         }
         for (let pol in policies.policy) {
             if (!isEmpty(policies.policy[pol])) {


### PR DESCRIPTION
Hi, 

this PR fixes an issue where the ```noParent``` policy is not being shown, even though it was active. 

Demo:
<img width="403" alt="image" src="https://github.com/kopia/htmlui/assets/37236531/c54d4186-a6c7-41ed-82fa-262b254931d3">


Cheers, 
