### PR TITLE
fix(ui): Fixing colors in dark theme

### DIFF
--- a/src/css/App.css
+++ b/src/css/App.css
@@ -66,6 +66,7 @@ body {
 #kopia .breadcrumb-item,
 #kopia .breadcrumb-item.active {
   color: var(--color-link);
+  --bs-breadcrumb-divider-color: var(--color-link);
 }
 
 #kopia a:hover,
@@ -77,6 +78,8 @@ body {
 #kopia .table,
 #kopia .table-hover>tbody>tr:hover>* {
   color: var(--color-text-body);
+  --bs-table-bg: var(--background-color);
+  --bs-table-color: var(--color-text-body);
 }
 
 #kopia .table-striped>tbody>tr:nth-of-type(odd)>* {

--- a/src/css/App.css
+++ b/src/css/App.css
@@ -433,3 +433,16 @@ div.tab-body {
   color: var(--color-badge-warning);
 }
 
+#kopia .pagination,
+#kopia .pagination-sm {
+  --bs-pagination-bg: var(--background-color);
+  --bs-pagination-disabled-bg: var(--background-color);
+  --bs-pagination-disabled-color: var(--color-text-body);
+  --bs-pagination-active-bg: var(--color-primary);
+  --bs-pagination-active-border-color: var(--color-primary);
+  --bs-pagination-active-color: var(--color-text-body);
+}
+
+#kopia li.page-item:disabled {
+  background-color: var(--background-color)
+}


### PR DESCRIPTION
Hi, 

this PR further fixes some color issues before moving to scss:

- Fixing the background color of the logs table
- Fixing the divider color of the breadcrumb navigation

This PR should fix https://github.com/kopia/kopia/issues/3379 and https://github.com/kopia/kopia/issues/3368

Feedback is welcomed. 

