### PR TITLE
fix(ui):  Fix hint text visibility in dark mode

### DIFF
--- a/src/css/App.css
+++ b/src/css/App.css
@@ -142,6 +142,10 @@ body {
   color: var(--color-text-form-help)
 }
 
+#kopia .form-control::placeholder {
+  color: var(--color-text-form-help);
+}
+
 #kopia .accordion-body,
 #kopia .accordion-button:not(.collapsed) {
   color: var(--color-text-body);


### PR DESCRIPTION
Hi, 

this PR fixes the hint text visibility in dark mode. It was overridden by the latest refactoring. 

Feedback is welcomed. 

Cheers, 
