### PR TITLE
feat(ui): Added directory selector for snapshots and filesystem repository

### DIFF
--- a/src/components/SetupRepositoryFilesystem.jsx
+++ b/src/components/SetupRepositoryFilesystem.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import { handleChange, validateRequiredFields } from '../forms';
 import { RequiredDirectory } from '../forms/RequiredDirectory';
+import { Row } from 'react-bootstrap';
 
 export class SetupRepositoryFilesystem extends Component {
     constructor(props) {
@@ -18,7 +19,7 @@ export class SetupRepositoryFilesystem extends Component {
 
     render() {
         return <>
-                {RequiredDirectory(this, "Directory Path", "path", { autoFocus: true, placeholder: "enter directory path where you want to store repository files"})}
+            {RequiredDirectory(this, "Directory Path", "path", { autoFocus: true, placeholder: "enter directory path where you want to store repository files"})}
         </>;
     }
 }

--- a/src/components/SetupRepositoryFilesystem.jsx
+++ b/src/components/SetupRepositoryFilesystem.jsx
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 import { handleChange, validateRequiredFields } from '../forms';
 import { RequiredDirectory } from '../forms/RequiredDirectory';
-import { Row } from 'react-bootstrap';
 
 export class SetupRepositoryFilesystem extends Component {
     constructor(props) {

--- a/src/components/SetupRepositoryFilesystem.jsx
+++ b/src/components/SetupRepositoryFilesystem.jsx
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
-import Row from 'react-bootstrap/Row';
 import { handleChange, validateRequiredFields } from '../forms';
-import { RequiredField } from '../forms/RequiredField';
+import { RequiredDirectory } from '../forms/RequiredDirectory';
 
 export class SetupRepositoryFilesystem extends Component {
     constructor(props) {
@@ -19,9 +18,7 @@ export class SetupRepositoryFilesystem extends Component {
 
     render() {
         return <>
-            <Row>
-                {RequiredField(this, "Directory Path", "path", { autoFocus: true, placeholder: "enter directory path where you want to store repository files" })}
-            </Row>
+                {RequiredDirectory(this, "Directory Path", "path", { autoFocus: true, placeholder: "enter directory path where you want to store repository files"})}
         </>;
     }
 }

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -3,8 +3,6 @@ body {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",
     "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
     sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
 }
 
 code {

--- a/src/forms/OptionalDirectory.jsx
+++ b/src/forms/OptionalDirectory.jsx
@@ -8,22 +8,20 @@ import { faFolderOpen } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { stateProperty } from '.';
 
-export function RequiredDirectory(component, label, name, props = {}, helpText = null) {
+export function OptionalDirectory(component, label, name, props = {}, helpText = null) {
     let { onDirectorySelected, ...inputProps } = props;
     return <FormGroup>
-        {label ? <Form.Label className="required">{label}</Form.Label> : <></>}
+        {label ? <Form.Label htmlFor='directoryInput' className="required">{label}</Form.Label> : <></>}
         <InputGroup as={Col}>
             <FormControl name={name} size="sm" id='directoryInput'
-                isInvalid={stateProperty(component, name, null) === ''}
                 value={stateProperty(component, name)}
                 onDirectorySelected={p => component.setState({ name: p })}
                 onChange={component.handleChange}{...inputProps}></FormControl>
-            {window.kopiaUI ? 
-            <Button size="sm" onClick={() => window.kopiaUI.selectDirectory(onDirectorySelected)}>
-                <FontAwesomeIcon icon={faFolderOpen} />
-            </Button> : <></>}
+            {window.kopiaUI ?
+                <Button size="sm" onClick={() => window.kopiaUI.selectDirectory(onDirectorySelected)}>
+                    <FontAwesomeIcon icon={faFolderOpen} />
+                </Button> : <></>}
             {helpText && <Form.Text className="text-muted">{helpText}</Form.Text>}
-            <Form.Control.Feedback type="invalid">Required field</Form.Control.Feedback>
         </InputGroup>
     </FormGroup>
 }

--- a/src/forms/OptionalDirectory.jsx
+++ b/src/forms/OptionalDirectory.jsx
@@ -1,27 +1,45 @@
 import React from 'react';
 import Button from 'react-bootstrap/Button';
 import Form from 'react-bootstrap/Form';
-import { Col, FormGroup } from 'react-bootstrap';
-import FormControl from 'react-bootstrap/FormControl';
-import InputGroup from 'react-bootstrap/InputGroup';
+import { Col, FormGroup, FormControl, InputGroup } from 'react-bootstrap';
 import { faFolderOpen } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { stateProperty } from '.';
+import { setDeepStateProperty } from '../utils/deepstate';
 
-export function OptionalDirectory(component, label, name, props = {}, helpText = null) {
-    let { onDirectorySelected, ...inputProps } = props;
+/**
+ * This functions returns a directory selector that allows the user to select a directory. 
+ * The selections is invoked using a button that calls a functions within the electron app. 
+ * If the electron app is not present, the button is not visible. 
+ * 
+ * @param {The component that this function is called from} component 
+ * @param {Label, that is added before the input field} label 
+ * @param {Name of the variable in which the directory path is stored} name 
+ * @param {Additional properties of the component} props 
+ * @returns The form group with the components
+ */
+export function OptionalDirectory(component, label, name, props = {}) {
+    /**
+     * Saves the selected path as a deepstate variable within the component
+     * @param {The path that has been selected} path 
+     */
+    function onDirectorySelected(path) {
+        setDeepStateProperty(component, name, path)
+    }
+    
     return <FormGroup>
-        {label ? <Form.Label htmlFor='directoryInput' className="required">{label}</Form.Label> : <></>}
+        {label && <Form.Label htmlFor='directoryInput' className="required">{label}</Form.Label>}
         <InputGroup as={Col}>
-            <FormControl name={name} size="sm" id='directoryInput'
+            <FormControl
+                id='directoryInput'
+                size="sm"
+                name={name}
                 value={stateProperty(component, name)}
-                onDirectorySelected={p => component.setState({ name: p })}
-                onChange={component.handleChange}{...inputProps}></FormControl>
-            {window.kopiaUI ?
+                onChange={component.handleChange}{...props}></FormControl>
+            {window.kopiaUI &&
                 <Button size="sm" onClick={() => window.kopiaUI.selectDirectory(onDirectorySelected)}>
                     <FontAwesomeIcon icon={faFolderOpen} />
-                </Button> : <></>}
-            {helpText && <Form.Text className="text-muted">{helpText}</Form.Text>}
+                </Button>}
         </InputGroup>
     </FormGroup>
 }

--- a/src/forms/OptionalDirectory.jsx
+++ b/src/forms/OptionalDirectory.jsx
@@ -35,6 +35,7 @@ export function OptionalDirectory(component, label, name, props = {}) {
                 size="sm"
                 name={name}
                 value={stateProperty(component, name)}
+                data-testid={'control-' + name}
                 onChange={component.handleChange}{...props}></FormControl>
             {window.kopiaUI &&
                 <Button size="sm" onClick={() => window.kopiaUI.selectDirectory(onDirectorySelected)}>

--- a/src/forms/OptionalDirectory.jsx
+++ b/src/forms/OptionalDirectory.jsx
@@ -12,10 +12,14 @@ import { setDeepStateProperty } from '../utils/deepstate';
  * The selections is invoked using a button that calls a functions within the electron app. 
  * If the electron app is not present, the button is not visible. 
  * 
- * @param {The component that this function is called from} component 
- * @param {Label, that is added before the input field} label 
- * @param {Name of the variable in which the directory path is stored} name 
- * @param {Additional properties of the component} props 
+ * @param {*} component
+ * The component that this function is called from 
+ * @param {string} label
+ * Label, that is added before the input field 
+ * @param {string} name
+ * Name of the variable in which the directory path is stored 
+ * @param {*} props
+ * Additional properties of the component 
  * @returns The form group with the components
  */
 export function OptionalDirectory(component, label, name, props = {}) {

--- a/src/forms/OptionalField.jsx
+++ b/src/forms/OptionalField.jsx
@@ -3,7 +3,7 @@ import Form from 'react-bootstrap/Form';
 import Col from 'react-bootstrap/Col';
 import { stateProperty } from '.';
 
-export function OptionalField(component, label, name, props = {}, helpText = null, invalidFeedback = null) {
+export function OptionalField(component, label, name, props = {}, helpText = null) {
     return <Form.Group as={Col}>
         <Form.Label>{label}</Form.Label>
         <Form.Control
@@ -14,6 +14,5 @@ export function OptionalField(component, label, name, props = {}, helpText = nul
             onChange={component.handleChange}
             {...props} />
         {helpText && <Form.Text className="text-muted">{helpText}</Form.Text>}
-        {invalidFeedback && <Form.Control.Feedback type="invalid">{invalidFeedback}</Form.Control.Feedback>}
     </Form.Group>;
 }

--- a/src/forms/RequiredDirectory.jsx
+++ b/src/forms/RequiredDirectory.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import Col from 'react-bootstrap/Col';
+import Button from 'react-bootstrap/Button';
+import Form from 'react-bootstrap/Form';
+import FormControl from 'react-bootstrap/FormControl';
+import InputGroup from 'react-bootstrap/InputGroup';
+import { faFolderOpen } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { stateProperty } from '.';
+
+export function RequiredDirectory(component, label, name, props = {}, helpText = null) {
+    let { onDirectorySelected, ...inputProps } = props;
+    if (!window.kopiaUI) {
+        return <Form.Control name={name} size="sm" isInvalid={stateProperty(component, name, null) === ''}
+        onChange={component.handleChange}
+            value={stateProperty(component, name)}{...inputProps} />
+    }
+    return <InputGroup as={Col}>
+        <Form.Label className="required">{label}</Form.Label>
+        <FormControl name={name} size="sm"
+            isInvalid={stateProperty(component, name, null) === ''}
+            value={stateProperty(component, name)}
+            onChange={component.handleChange}{...inputProps} />
+        <Button size="sm" onClick={() => window.kopiaUI.selectDirectory(onDirectorySelected)}>
+            <FontAwesomeIcon icon={faFolderOpen} />
+        </Button>
+
+        {helpText && <Form.Text className="text-muted">{helpText}</Form.Text>}
+        <Form.Control.Feedback type="invalid">Required field</Form.Control.Feedback>
+    </InputGroup>
+}

--- a/src/forms/RequiredDirectory.jsx
+++ b/src/forms/RequiredDirectory.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import Col from 'react-bootstrap/Col';
 import Button from 'react-bootstrap/Button';
 import Form from 'react-bootstrap/Form';
+import { Col } from 'react-bootstrap';
 import FormControl from 'react-bootstrap/FormControl';
 import InputGroup from 'react-bootstrap/InputGroup';
 import { faFolderOpen } from '@fortawesome/free-solid-svg-icons';
@@ -11,21 +11,28 @@ import { stateProperty } from '.';
 export function RequiredDirectory(component, label, name, props = {}, helpText = null) {
     let { onDirectorySelected, ...inputProps } = props;
     if (!window.kopiaUI) {
-        return <Form.Control name={name} size="sm" isInvalid={stateProperty(component, name, null) === ''}
-        onChange={component.handleChange}
-            value={stateProperty(component, name)}{...inputProps} />
+        return <>
+            <Form.Label className="required">{label}</Form.Label>
+            <InputGroup as={Col}>
+                <Form.Control name={name} size="sm" isInvalid={stateProperty(component, name, null) === ''}
+                    onChange={component.handleChange}
+                    value={stateProperty(component, name)}{...inputProps} /></InputGroup>
+        </>
     }
-    return <InputGroup as={Col}>
-        <Form.Label className="required">{label}</Form.Label>
-        <FormControl name={name} size="sm"
-            isInvalid={stateProperty(component, name, null) === ''}
-            value={stateProperty(component, name)}
-            onChange={component.handleChange}{...inputProps} />
-        <Button size="sm" onClick={() => window.kopiaUI.selectDirectory(onDirectorySelected)}>
-            <FontAwesomeIcon icon={faFolderOpen} />
-        </Button>
+    return <>
+        <Form.Label htmlFor='directoryInput' className="required">{label}</Form.Label>
+        <InputGroup as={Col}>
+            <FormControl name={name} size="sm" id='directoryInput'
+                isInvalid={stateProperty(component, name, null) === ''}
+                value={stateProperty(component, name)}
+                onChange={component.handleChange}{...inputProps}></FormControl>
 
-        {helpText && <Form.Text className="text-muted">{helpText}</Form.Text>}
-        <Form.Control.Feedback type="invalid">Required field</Form.Control.Feedback>
-    </InputGroup>
+            <Button size="sm" onClick={() => window.kopiaUI.selectDirectory(onDirectorySelected)}>
+                <FontAwesomeIcon icon={faFolderOpen} />
+            </Button>
+
+            {helpText && <Form.Text className="text-muted">{helpText}</Form.Text>}
+            <Form.Control.Feedback type="invalid">Required field</Form.Control.Feedback>
+        </InputGroup>
+    </>
 }

--- a/src/forms/RequiredDirectory.jsx
+++ b/src/forms/RequiredDirectory.jsx
@@ -36,6 +36,7 @@ export function RequiredDirectory(component, label, name, props = {}) {
                 name={name}
                 isInvalid={stateProperty(component, name, null) === ''}
                 value={stateProperty(component, name)}
+                data-testid={'control-' + name}
                 onChange={component.handleChange}{...props}></FormControl>
             {window.kopiaUI &&
                 <Button size="sm" onClick={() => window.kopiaUI.selectDirectory(onDirectorySelected)}>

--- a/src/forms/RequiredDirectory.jsx
+++ b/src/forms/RequiredDirectory.jsx
@@ -12,10 +12,14 @@ import { setDeepStateProperty } from '../utils/deepstate';
  * The selections is invoked using a button that calls a functions within the electron app. 
  * If the electron app is not present, the button is not visible. The path is required.
  * 
- * @param {The component that this function is called from} component 
- * @param {Label, that is added before the input field} label 
- * @param {Name of the variable in which the directory path is stored} name 
- * @param {Additional properties of the component} props 
+ * @param {*} component
+ * The component that this function is called from 
+ * @param {string} label
+ * Label, that is added before the input field 
+ * @param {string} name
+ * Name of the variable in which the directory path is stored 
+ * @param {*} props
+ * Additional properties of the component 
  * @returns The form group with the components
  */
 export function RequiredDirectory(component, label, name, props = {}) {

--- a/src/forms/RequiredDirectory.jsx
+++ b/src/forms/RequiredDirectory.jsx
@@ -1,28 +1,46 @@
 import React from 'react';
 import Button from 'react-bootstrap/Button';
 import Form from 'react-bootstrap/Form';
-import { Col, FormGroup } from 'react-bootstrap';
-import FormControl from 'react-bootstrap/FormControl';
-import InputGroup from 'react-bootstrap/InputGroup';
+import { Col, FormGroup, FormControl, InputGroup } from 'react-bootstrap';
 import { faFolderOpen } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { stateProperty } from '.';
+import { setDeepStateProperty } from '../utils/deepstate';
 
-export function RequiredDirectory(component, label, name, props = {}, helpText = null) {
-    let { onDirectorySelected, ...inputProps } = props;
+/**
+ * This functions returns a directory selector that allows the user to select a directory. 
+ * The selections is invoked using a button that calls a functions within the electron app. 
+ * If the electron app is not present, the button is not visible. The path is required.
+ * 
+ * @param {The component that this function is called from} component 
+ * @param {Label, that is added before the input field} label 
+ * @param {Name of the variable in which the directory path is stored} name 
+ * @param {Additional properties of the component} props 
+ * @returns The form group with the components
+ */
+export function RequiredDirectory(component, label, name, props = {}) {
+    /**
+    * Saves the selected path as a deepstate variable within the component
+    * @param {The path that has been selected} path 
+    */
+    function onDirectorySelected(path) {
+        setDeepStateProperty(component, name, path)
+    }
+    
     return <FormGroup>
-        {label ? <Form.Label className="required">{label}</Form.Label> : <></>}
+        {label && <Form.Label className="required">{label}</Form.Label>}
         <InputGroup as={Col}>
-            <FormControl name={name} size="sm" id='directoryInput'
+            <FormControl
+                id='directoryInput'
+                size="sm"
+                name={name}
                 isInvalid={stateProperty(component, name, null) === ''}
                 value={stateProperty(component, name)}
-                onDirectorySelected={p => component.setState({ name: p })}
-                onChange={component.handleChange}{...inputProps}></FormControl>
-            {window.kopiaUI ? 
-            <Button size="sm" onClick={() => window.kopiaUI.selectDirectory(onDirectorySelected)}>
-                <FontAwesomeIcon icon={faFolderOpen} />
-            </Button> : <></>}
-            {helpText && <Form.Text className="text-muted">{helpText}</Form.Text>}
+                onChange={component.handleChange}{...props}></FormControl>
+            {window.kopiaUI &&
+                <Button size="sm" onClick={() => window.kopiaUI.selectDirectory(onDirectorySelected)}>
+                    <FontAwesomeIcon icon={faFolderOpen} />
+                </Button>}
             <Form.Control.Feedback type="invalid">Required field</Form.Control.Feedback>
         </InputGroup>
     </FormGroup>

--- a/src/pages/Policies.jsx
+++ b/src/pages/Policies.jsx
@@ -10,8 +10,9 @@ import Form from 'react-bootstrap/Form';
 import Row from 'react-bootstrap/Row';
 import { Link } from 'react-router-dom';
 import { handleChange } from '../forms';
+import { OptionalDirectory } from '../forms/OptionalDirectory'
 import KopiaTable from '../utils/KopiaTable';
-import { CLIEquivalent, compare, DirectorySelector, isAbsolutePath, ownerName, policyEditorURL, redirect } from '../utils/uiutil';
+import { CLIEquivalent, compare, isAbsolutePath, ownerName, policyEditorURL, redirect } from '../utils/uiutil';
 
 const applicablePolicies = "Applicable Policies"
 const localPolicies = "Local Path Policies"
@@ -274,9 +275,7 @@ export class Policies extends Component {
                         </Col>
                         {(this.state.selectedOwner === localPolicies || this.state.selectedOwner === this.state.localSourceName || this.state.selectedOwner === applicablePolicies) ? <>
                             <Col>
-                                <DirectorySelector autoFocus onDirectorySelected={p => this.setState({ policyPath: p })}
-                                    placeholder="enter directory to find or set policy"
-                                    name="policyPath" value={this.state.policyPath} onChange={this.handleChange} />
+                                {OptionalDirectory(this, null, "policyPath", { autoFocus: true, placeholder: "enter directory to find or set policy" })}
                             </Col>
                             <Col xs="auto">
                                 <Button disabled={!this.state.policyPath} size="sm" type="submit" onClick={this.editPolicyForPath}>Set Policy</Button>

--- a/src/pages/SnapshotCreate.jsx
+++ b/src/pages/SnapshotCreate.jsx
@@ -60,7 +60,7 @@ export class SnapshotCreate extends Component {
             } else {
                 this.setState({
                     lastResolvedPath: currentPath,
-                    resolvedSource: null,
+                    resolvedSource: "",
                 });
 
                 this.maybeResolveCurrentPath(currentPath);

--- a/src/pages/SnapshotCreate.jsx
+++ b/src/pages/SnapshotCreate.jsx
@@ -7,7 +7,8 @@ import Row from 'react-bootstrap/Row';
 import { handleChange } from '../forms';
 import { PolicyEditor } from '../components/policy-editor/PolicyEditor';
 import { SnapshotEstimation } from '../components/SnapshotEstimation';
-import { CLIEquivalent, DirectorySelector, errorAlert, GoBackButton, redirect } from '../utils/uiutil';
+import { RequiredDirectory } from '../forms/RequiredDirectory';
+import { CLIEquivalent, errorAlert, GoBackButton, redirect } from '../utils/uiutil';
 
 export class SnapshotCreate extends Component {
     constructor() {
@@ -147,18 +148,15 @@ export class SnapshotCreate extends Component {
 
     render() {
         return <>
-            <Row>
                 <Form.Group>
                     <GoBackButton onClick={this.props.history.goBack} />
                 </Form.Group>
-                &nbsp;&nbsp;&nbsp;<h4>New Snapshot</h4>
-            </Row>
+                <br/>
+                <h4>New Snapshot</h4>
             <br />
             <Row>
                 <Col>
-                    <Form.Group>
-                        <DirectorySelector onDirectorySelected={p => this.setState({ path: p })} autoFocus placeholder="enter path to snapshot" name="path" value={this.state.path} onChange={this.handleChange} />
-                    </Form.Group>
+                    {RequiredDirectory(this, "Directory Path", "path", { autoFocus: true, placeholder: "enter path to snapshot" })}
                 </Col>
                 <Col xs="auto">
                     <Button
@@ -168,7 +166,6 @@ export class SnapshotCreate extends Component {
                         title="Estimate"
                         variant="secondary"
                         onClick={this.estimate}>Estimate</Button>
-                    &nbsp;
                     <Button
                         data-testid='snapshot-now'
                         size="sm"

--- a/src/pages/SnapshotCreate.jsx
+++ b/src/pages/SnapshotCreate.jsx
@@ -148,15 +148,15 @@ export class SnapshotCreate extends Component {
 
     render() {
         return <>
-                <Form.Group>
-                    <GoBackButton onClick={this.props.history.goBack} />
-                </Form.Group>
-                <br/>
-                <h4>New Snapshot</h4>
+            <Form.Group>
+                <GoBackButton onClick={this.props.history.goBack} />
+            </Form.Group>
+            <br />
+            <h4>New Snapshot</h4>
             <br />
             <Row>
                 <Col>
-                    {RequiredDirectory(this, "Directory Path", "path", { autoFocus: true, placeholder: "enter path to snapshot" })}
+                    {RequiredDirectory(this, null, "path", { autoFocus: true, placeholder: "enter path to snapshot" })}
                 </Col>
                 <Col xs="auto">
                     <Button
@@ -179,21 +179,17 @@ export class SnapshotCreate extends Component {
                 <SnapshotEstimation taskID={this.state.estimateTaskID} hideDescription={true} showZeroCounters={true} />
             }
             <br />
-
             {this.state.resolvedSource && <Row><Col xs={12}>
                 <Form.Text>
                     {this.state.resolvedSource ? this.state.resolvedSource.path : this.state.path}
                 </Form.Text>
-
                 <PolicyEditor ref={this.policyEditorRef}
                     embedded
                     host={this.state.resolvedSource.host}
                     userName={this.state.resolvedSource.userName}
                     path={this.state.resolvedSource.path} />
             </Col></Row>}
-
-            <Row><Col>&nbsp;</Col></Row>
-
+            <br />
             <CLIEquivalent command={`snapshot create ${this.state.resolvedSource ? this.state.resolvedSource.path : this.state.path}`} />
         </>;
     }

--- a/src/utils/uiutil.jsx
+++ b/src/utils/uiutil.jsx
@@ -1,9 +1,8 @@
-import { faBan, faCheck, faChevronLeft, faCopy, faExclamationCircle, faExclamationTriangle, faFolderOpen, faTerminal, faXmark } from '@fortawesome/free-solid-svg-icons';
+import { faBan, faCheck, faChevronLeft, faCopy, faExclamationCircle, faExclamationTriangle, faTerminal, faXmark } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import axios from 'axios';
 import React, { useState } from 'react';
 import Button from 'react-bootstrap/Button';
-import Form from 'react-bootstrap/Form';
 import FormControl from 'react-bootstrap/FormControl';
 import InputGroup from 'react-bootstrap/InputGroup';
 import Spinner from 'react-bootstrap/Spinner';
@@ -365,27 +364,6 @@ export function errorAlert(err, prefix) {
     } else {
         alert(prefix + JSON.stringify(err));
     }
-}
-
-/**
- * A selector that openes a file browser to select a directory. 
- * The selector checks, if the it is used in the context of the native or web-ui.
- * @param {*} props 
- * @returns 
- */
-export function DirectorySelector(props) {
-    let { onDirectorySelected, ...inputProps } = props;
-
-    if (!window.kopiaUI) {
-        return <Form.Control size="sm" {...inputProps} />
-    }
-
-    return <InputGroup>
-        <FormControl size="sm" {...inputProps} />
-        <Button size="sm" onClick={() => window.kopiaUI.selectDirectory(onDirectorySelected)}>
-            <FontAwesomeIcon icon={faFolderOpen} />
-        </Button>
-    </InputGroup>;
 }
 
 export function CLIEquivalent(props) {

--- a/src/utils/uiutil.jsx
+++ b/src/utils/uiutil.jsx
@@ -367,6 +367,12 @@ export function errorAlert(err, prefix) {
     }
 }
 
+/**
+ * A selector that openes a file browser to select a directory. 
+ * The selector checks, if the it is used in the context of the native or web-ui.
+ * @param {*} props 
+ * @returns 
+ */
 export function DirectorySelector(props) {
     let { onDirectorySelected, ...inputProps } = props;
 


### PR DESCRIPTION
Hi, 

this PR comes with the following changes:

- Rewrote the directory selector and added a required and optional directory selector
- Added the directory selector to snapshot create and filesystem repository
- Fixed a bug, where the deletion of the snapshot path result in a nullpointer reference

This pr will fix https://github.com/kopia/kopia/issues/3453

Feedback is welcomed,

Cheers