### PR TITLE
feat(ui): Add multi-language support for kopia-ui

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,10 +15,13 @@
         "@fortawesome/react-fontawesome": "^0.2.0",
         "bootstrap": "^5.3.1",
         "http-proxy-middleware": "^2.0.6",
+        "i18next": "^23.10.1",
+        "i18next-http-backend": "^2.5.0",
         "moment": "^2.30.1",
         "react": "^18.2.0",
         "react-bootstrap": "^2.8.0",
         "react-dom": "^18.2.0",
+        "react-i18next": "^14.1.0",
         "react-router-dom": "^5.3.4",
         "react-table": "^7.8.0"
       },
@@ -2096,11 +2099,11 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.22.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.6.tgz",
-      "integrity": "sha512-wDb5pWm4WDdF6LFUde3Jl8WzPA+3ZbxYqkC6xAXuD3irdEHN1k0NfTRrJD8ZD378SJ61miMLCqIOXYhd8x+AJQ==",
+      "version": "7.24.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.0.tgz",
+      "integrity": "sha512-Chk32uHMg6TnQdvw2e9IlqPpFX/6NLuK0Ys2PqLb7/gL5uFn9mXvK715FGLlOLQrcO4qIkNHkvPGktzzXexsFw==",
       "dependencies": {
-        "regenerator-runtime": "^0.13.11"
+        "regenerator-runtime": "^0.14.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2118,6 +2121,11 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@babel/runtime/node_modules/regenerator-runtime": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
     },
     "node_modules/@babel/template": {
       "version": "7.22.15",
@@ -6744,6 +6752,14 @@
         "node": ">=10"
       }
     },
+    "node_modules/cross-fetch": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
+      "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
+      "dependencies": {
+        "node-fetch": "^2.6.12"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -9523,6 +9539,14 @@
         "node": ">=12"
       }
     },
+    "node_modules/html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "dependencies": {
+        "void-elements": "3.1.0"
+      }
+    },
     "node_modules/html-webpack-plugin": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.5.0.tgz",
@@ -9663,6 +9687,36 @@
       "dev": true,
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/i18next": {
+      "version": "23.10.1",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-23.10.1.tgz",
+      "integrity": "sha512-NDiIzFbcs3O9PXpfhkjyf7WdqFn5Vq6mhzhtkXzj51aOcNuPNcTwuYNuXCpHsanZGHlHKL35G7huoFeVic1hng==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "dependencies": {
+        "@babel/runtime": "^7.23.2"
+      }
+    },
+    "node_modules/i18next-http-backend": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/i18next-http-backend/-/i18next-http-backend-2.5.0.tgz",
+      "integrity": "sha512-Z/aQsGZk1gSxt2/DztXk92DuDD20J+rNudT7ZCdTrNOiK8uQppfvdjq9+DFQfpAnFPn3VZS+KQIr1S/W1KxhpQ==",
+      "dependencies": {
+        "cross-fetch": "4.0.0"
       }
     },
     "node_modules/iconv-lite": {
@@ -13865,6 +13919,44 @@
         "tslib": "^2.0.3"
       }
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/node-forge": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
@@ -16133,6 +16225,27 @@
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg==",
       "dev": true
     },
+    "node_modules/react-i18next": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-14.1.0.tgz",
+      "integrity": "sha512-3KwX6LHpbvGQ+sBEntjV4sYW3Zovjjl3fpoHbUwSgFHf0uRBcbeCBLR5al6ikncI5+W0EFb71QXZmfop+J6NrQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.23.9",
+        "html-parse-stringify": "^3.0.1"
+      },
+      "peerDependencies": {
+        "i18next": ">= 23.2.3",
+        "react": ">= 16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -17405,7 +17518,8 @@
     "node_modules/regenerator-runtime": {
       "version": "0.13.11",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "dev": true
     },
     "node_modules/regenerator-transform": {
       "version": "0.15.0",
@@ -19303,6 +19417,14 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/w3c-hr-time": {
@@ -21696,11 +21818,18 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.22.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.6.tgz",
-      "integrity": "sha512-wDb5pWm4WDdF6LFUde3Jl8WzPA+3ZbxYqkC6xAXuD3irdEHN1k0NfTRrJD8ZD378SJ61miMLCqIOXYhd8x+AJQ==",
+      "version": "7.24.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.0.tgz",
+      "integrity": "sha512-Chk32uHMg6TnQdvw2e9IlqPpFX/6NLuK0Ys2PqLb7/gL5uFn9mXvK715FGLlOLQrcO4qIkNHkvPGktzzXexsFw==",
       "requires": {
-        "regenerator-runtime": "^0.13.11"
+        "regenerator-runtime": "^0.14.0"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.14.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+          "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
+        }
       }
     },
     "@babel/runtime-corejs3": {
@@ -25262,6 +25391,14 @@
         "yaml": "^1.10.0"
       }
     },
+    "cross-fetch": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
+      "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
+      "requires": {
+        "node-fetch": "^2.6.12"
+      }
+    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -27349,6 +27486,14 @@
         "terser": "^5.10.0"
       }
     },
+    "html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "requires": {
+        "void-elements": "3.1.0"
+      }
+    },
     "html-webpack-plugin": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.5.0.tgz",
@@ -27447,6 +27592,22 @@
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
       "dev": true
+    },
+    "i18next": {
+      "version": "23.10.1",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-23.10.1.tgz",
+      "integrity": "sha512-NDiIzFbcs3O9PXpfhkjyf7WdqFn5Vq6mhzhtkXzj51aOcNuPNcTwuYNuXCpHsanZGHlHKL35G7huoFeVic1hng==",
+      "requires": {
+        "@babel/runtime": "^7.23.2"
+      }
+    },
+    "i18next-http-backend": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/i18next-http-backend/-/i18next-http-backend-2.5.0.tgz",
+      "integrity": "sha512-Z/aQsGZk1gSxt2/DztXk92DuDD20J+rNudT7ZCdTrNOiK8uQppfvdjq9+DFQfpAnFPn3VZS+KQIr1S/W1KxhpQ==",
+      "requires": {
+        "cross-fetch": "4.0.0"
+      }
     },
     "iconv-lite": {
       "version": "0.6.3",
@@ -30800,6 +30961,35 @@
         "tslib": "^2.0.3"
       }
     },
+    "node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      },
+      "dependencies": {
+        "tr46": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+          "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+        },
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
+          }
+        }
+      }
+    },
     "node-forge": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
@@ -32314,6 +32504,15 @@
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg==",
       "dev": true
     },
+    "react-i18next": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-14.1.0.tgz",
+      "integrity": "sha512-3KwX6LHpbvGQ+sBEntjV4sYW3Zovjjl3fpoHbUwSgFHf0uRBcbeCBLR5al6ikncI5+W0EFb71QXZmfop+J6NrQ==",
+      "requires": {
+        "@babel/runtime": "^7.23.9",
+        "html-parse-stringify": "^3.0.1"
+      }
+    },
     "react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -33318,7 +33517,8 @@
     "regenerator-runtime": {
       "version": "0.13.11",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "dev": true
     },
     "regenerator-transform": {
       "version": "0.15.0",
@@ -34768,6 +34968,11 @@
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "dev": true
+    },
+    "void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w=="
     },
     "w3c-hr-time": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -9,10 +9,13 @@
     "@fortawesome/react-fontawesome": "^0.2.0",
     "bootstrap": "^5.3.1",
     "http-proxy-middleware": "^2.0.6",
+    "i18next": "^23.10.1",
+    "i18next-http-backend": "^2.5.0",
     "moment": "^2.30.1",
     "react": "^18.2.0",
     "react-bootstrap": "^2.8.0",
     "react-dom": "^18.2.0",
+    "react-i18next": "^14.1.0",
     "react-router-dom": "^5.3.4",
     "react-table": "^7.8.0"
   },

--- a/public/locales/de-DE/translation.json
+++ b/public/locales/de-DE/translation.json
@@ -1,0 +1,22 @@
+{
+	"user.interface": "Benutzeroberfläche",
+
+	"lang.en": "Englisch",
+	"lang.de": "Deutsch",
+	"lang.es": "Spanisch",
+	"lang.help": "Ändert die Sprache",
+	"lang.select": "Select language",
+	"lang.description": "Select the language",
+
+	"theme.description": "Theme",
+	"theme.select":"Theme auswählen",
+	"theme.help": "Das aktuelle Theme",
+	"theme.dark":"Dunkel",
+	"theme.light": "Hell",
+	"theme.pastel": "Pastelfarbend",
+	"theme.ocean":"Ozean",
+
+	"byte.representation.description":"Byte Darstellung",
+	"byte.representation.select": "Darstellung der Bytes auswählen",
+	"byte.representation.help": "Gibt die Darstellung der Bytes an"
+}

--- a/public/locales/de-DE/translation.json
+++ b/public/locales/de-DE/translation.json
@@ -1,16 +1,29 @@
 {
 	"user.interface": "Benutzeroberfläche",
+	"user.interface.appearance":"Erscheinungsbild",
+	"user.interface.appearance.small":"klein",
+	"user.interface.appearance.medium":"mittel",
+	"user.interface.appearance.large":"groß",
+
+	"user.interface.pagesize.description": "Page size",
+	"user.interface.pagesize.help": "Specifies the pagination size in tables",
+	"user.interface.pagesize.hint": "Page size",
 
 	"lang.en": "Englisch",
 	"lang.de": "Deutsch",
 	"lang.es": "Spanisch",
+	"lang.fr": "Französisch",
+	"lang.ru": "Russisch",
+	"lang.jp": "Japanisch",
+	"lang.it": "Italienisch",
+
 	"lang.help": "Ändert die Sprache",
 	"lang.select": "Select language",
 	"lang.description": "Select the language",
 
-	"theme.description": "Theme",
-	"theme.select":"Theme auswählen",
-	"theme.help": "Das aktuelle Theme",
+	"theme.description": "Thema",
+	"theme.select":"Thema auswählen",
+	"theme.help": "Das aktuelle Thema",
 	"theme.dark":"Dunkel",
 	"theme.light": "Hell",
 	"theme.pastel": "Pastelfarbend",

--- a/public/locales/en-GB/translation.json
+++ b/public/locales/en-GB/translation.json
@@ -1,0 +1,21 @@
+{
+	"user.interface": "User interface",
+
+	"lang.en": "English",
+	"lang.de": "German",
+	"lang.es": "Spanish",
+	"lang.help": "Sets the language for the user interface",
+	"lang.select": "Select language",
+	"lang.select.description": "Select the language",
+
+	"theme.description": "Theme",
+	"theme.select": "Select theme",
+	"theme.help": "The current active theme",
+	"theme.dark":"dark",
+	"theme.light": "light",
+	"theme.pastel": "pastel",
+	"theme.ocean":"ocean",
+
+	"byte.representation.select":"Select byte representation",
+	"byte.representation.help":"Specifies the representation of bytes"
+}

--- a/public/locales/es-ES/translation.json
+++ b/public/locales/es-ES/translation.json
@@ -1,21 +1,35 @@
 {
-	"user.interface": "User interface",
+	"user.interface": "Interfaz de usuario",
+	"user.interface.appearance":"Presentación",
+	"user.interface.appearance.small":"pequeño",
+	"user.interface.appearance.medium":"medio",
+	"user.interface.appearance.large":"gran",
 
-	"lang.en": "Ingles",
-	"lang.de": "German",
-	"lang.es": "Spanish",
-	"lang.help": "Sets the language for the user interface",
-	"lang.select": "Select language",
-	"lang.select.description": "Select the language",
+	"user.interface.pagesize.description": "Page size",
+	"user.interface.pagesize.help": "Specifies the pagination size in tables",
+	"user.interface.pagesize.hint": "Page size",
 
-	"theme.description": "Theme",
+	"lang.en": "Inglés",
+	"lang.de": "Alemán",
+	"lang.es": "Español",
+	"lang.fr": "Francés",
+	"lang.ru": "Russian",
+	"lang.jp": "Japanese",
+	"lang.it": "Italian",
+	
+	"lang.help": "Establece el idioma de la interfaz de usuario",
+	"lang.select": "Seleccionar idioma",
+	"lang.description": "Seleccione el idioma",
+
+	"theme.description": "Tema",
 	"theme.select": "Select theme",
 	"theme.help": "The current active theme",
-	"theme.dark":"dark",
-	"theme.light": "light",
+	"theme.dark":"oscuro",
+	"theme.light": "luz",
 	"theme.pastel": "pastel",
-	"theme.ocean":"ocean",
+	"theme.ocean":"océano",
 
+	"byte.representation.description":"Select byte representation",
 	"byte.representation.select":"Select byte representation",
 	"byte.representation.help":"Specifies the representation of bytes"
 }

--- a/public/locales/es-ES/translation.json
+++ b/public/locales/es-ES/translation.json
@@ -1,0 +1,21 @@
+{
+	"user.interface": "User interface",
+
+	"lang.en": "Ingles",
+	"lang.de": "German",
+	"lang.es": "Spanish",
+	"lang.help": "Sets the language for the user interface",
+	"lang.select": "Select language",
+	"lang.select.description": "Select the language",
+
+	"theme.description": "Theme",
+	"theme.select": "Select theme",
+	"theme.help": "The current active theme",
+	"theme.dark":"dark",
+	"theme.light": "light",
+	"theme.pastel": "pastel",
+	"theme.ocean":"ocean",
+
+	"byte.representation.select":"Select byte representation",
+	"byte.representation.help":"Specifies the representation of bytes"
+}

--- a/public/locales/fr-FR/translation.json
+++ b/public/locales/fr-FR/translation.json
@@ -1,5 +1,5 @@
 {
-	"user.interface": "User interface",
+	"user.interface": "Interface utilisateur",
 	"user.interface.appearance":"Appearance",
 	"user.interface.appearance.small":"small",
 	"user.interface.appearance.medium":"medium",
@@ -12,11 +12,11 @@
 	"lang.en": "English",
 	"lang.de": "German",
 	"lang.es": "Spanish",
-	"lang.fr": "French",
+	"lang.fr": "Français",
 	"lang.ru": "Russian",
 	"lang.jp": "Japanese",
 	"lang.it": "Italian",
-
+	
 	"lang.help": "Sets the language for the user interface",
 	"lang.select": "Select language",
 	"lang.description": "Select the language",

--- a/public/locales/it-IT/translation.json
+++ b/public/locales/it-IT/translation.json
@@ -1,5 +1,5 @@
 {
-	"user.interface": "User interface",
+	"user.interface": "Interface utilisateur",
 	"user.interface.appearance":"Appearance",
 	"user.interface.appearance.small":"small",
 	"user.interface.appearance.medium":"medium",
@@ -12,11 +12,11 @@
 	"lang.en": "English",
 	"lang.de": "German",
 	"lang.es": "Spanish",
-	"lang.fr": "French",
+	"lang.fr": "Français",
 	"lang.ru": "Russian",
 	"lang.jp": "Japanese",
 	"lang.it": "Italian",
-
+	
 	"lang.help": "Sets the language for the user interface",
 	"lang.select": "Select language",
 	"lang.description": "Select the language",

--- a/public/locales/jp-JP/translation.json
+++ b/public/locales/jp-JP/translation.json
@@ -1,5 +1,5 @@
 {
-	"user.interface": "User interface",
+	"user.interface": "Interface utilisateur",
 	"user.interface.appearance":"Appearance",
 	"user.interface.appearance.small":"small",
 	"user.interface.appearance.medium":"medium",
@@ -12,11 +12,11 @@
 	"lang.en": "English",
 	"lang.de": "German",
 	"lang.es": "Spanish",
-	"lang.fr": "French",
+	"lang.fr": "Français",
 	"lang.ru": "Russian",
 	"lang.jp": "Japanese",
 	"lang.it": "Italian",
-
+	
 	"lang.help": "Sets the language for the user interface",
 	"lang.select": "Select language",
 	"lang.description": "Select the language",

--- a/public/locales/ru-RU/translation.json
+++ b/public/locales/ru-RU/translation.json
@@ -1,5 +1,5 @@
 {
-	"user.interface": "User interface",
+	"user.interface": "Interface utilisateur",
 	"user.interface.appearance":"Appearance",
 	"user.interface.appearance.small":"small",
 	"user.interface.appearance.medium":"medium",
@@ -12,11 +12,11 @@
 	"lang.en": "English",
 	"lang.de": "German",
 	"lang.es": "Spanish",
-	"lang.fr": "French",
+	"lang.fr": "Français",
 	"lang.ru": "Russian",
 	"lang.jp": "Japanese",
 	"lang.it": "Italian",
-
+	
 	"lang.help": "Sets the language for the user interface",
 	"lang.select": "Select language",
 	"lang.description": "Select the language",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -36,6 +36,7 @@ export default class App extends Component {
     this.fetchInitialRepositoryDescription = this.fetchInitialRepositoryDescription.bind(this);
 
     const tok = document.head.querySelector('meta[name="kopia-csrf-token"]');
+    
     if (tok && tok.content) {
       axios.defaults.headers.common['X-Kopia-Csrf-Token'] = tok.content;
     } else {

--- a/src/contexts/UIPreferencesContext.tsx
+++ b/src/contexts/UIPreferencesContext.tsx
@@ -12,7 +12,7 @@ const DEFAULT_PREFERENCES = { pageSize: PAGE_SIZES[0], bytesStringBase2: false, 
 export type Theme = "light" | "dark" | "pastel" | "ocean";
 export type PageSize = 10 | 20 | 30 | 40 | 50 | 100;
 export type FontSize = "fs-6" | "fs-5" | "fs-4";
-export type Language = "en-GB" | "de-DE" | "es-ES";
+export type Language = "en-GB" | "de-DE" | "es-ES" | "fr-FR" | "jp-JP" | "ru-RU" | "it-IT";
 
 export interface UIPreferences {
     get pageSize(): PageSize

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 import './css/index.css';
+import './utils/18ns';
 
 const root = createRoot(document.getElementById('root'))
 root.render(<App />);

--- a/src/pages/Preferences.jsx
+++ b/src/pages/Preferences.jsx
@@ -1,52 +1,73 @@
-import { Component } from 'react';
+import Accordion from 'react-bootstrap/Accordion';
 import { UIPreferencesContext } from '../contexts/UIPreferencesContext';
+import { useContext } from 'react';
+import { useTranslation } from "react-i18next";
 
 /**
  * Class that exports preferences
  */
-export class Preferences extends Component {
-    render() {
-        const { pageSize, theme, bytesStringBase2, fontSize, setByteStringBase, setTheme, setFontSize} = this.context;
-        return <>
-            <form>
-                <div className='form-group'>
-                    <label className='label-description' htmlFor='themeSelector' id='themeLabel'>Theme</label>
-                    <select className="form-select form-select-sm" title='Select theme' id='themeSelector' value={theme} onChange={e => setTheme(e.target.value)}>
-                        <option value="light">light</option>
-                        <option value="dark">dark</option>
-                        <option value="pastel">pastel</option>
-                        <option value="ocean">ocean</option>
-                    </select>
-                    <small hmtlfor='themeLabel' id='themeHelp' className='form-text text-muted'>The current active theme</small>
-                </div>
-                <br />
-                <div className='form-group'>
-                    <label className='label-description' htmlFor="bytesBaseInput">Byte representation</label>
-                    <select className="form-select form-select-sm" title='Select byte representation' id='bytesBaseInput' value={bytesStringBase2} onChange={e => setByteStringBase(e.target.value)}>
-                        <option value="true">Base-2 (KiB, MiB, GiB, TiB)</option>
-                        <option value="false">Base-10 (KB, MB, GB, TB)</option>
-                    </select>
-                    <small hmtlfor='bytesBaseInput' id='bytesHelp' className='form-text text-muted'>Specifies the representation of bytes</small>
-                </div>
-                <br />
-                <div className='form-group'>
-                    <label className='label-description'>Appearance</label>
-                    <select className="form-select form-select-sm" title='Select font size' id='fontSizeInput' value={fontSize} onChange={e => setFontSize(e.target.value)}>
-                        <option value="fs-6">small</option>
-                        <option value="fs-5">medium</option>
-                        <option value="fs-4">large</option>
-                    </select>
-                    <small hmtlfor="fontSizeInput" id='fontSizeHelp' className='form-text text-muted'>Specifies the appearance of the user interface</small>
-                </div>
-                <br />
-                <div className='form-group'>
-                    <label className='label-description'>Page size</label>
-                    <input className='form-control form-control-sm' id='pageSizeInput'
-                        type='text' placeholder='Page size' value={pageSize} disabled={true} />
-                    <small hmtlfor="pageSizeInput" id='pageSizeHelp' className='form-text text-muted'>Specifies the pagination size in tables</small>
-                </div>
-            </form>
-        </>
-    }
+export function Preferences() {
+    const { t } = useTranslation();
+    const { pageSize, theme, bytesStringBase2, fontSize, language, setFontSize, setByteStringBase, setTheme, setLanguage } = useContext(UIPreferencesContext);
+    return <>
+        <Accordion defaultActiveKey="user_interface">
+            <Accordion.Item eventKey="user_interface">
+                <Accordion.Header>{t('user.interface')}</Accordion.Header>
+                <Accordion.Body>
+                    <form>
+                        <div className='form-group'>
+                            <label className='label-description' htmlFor='themeSelector' id='themeLabel'>{t('theme.description')}</label>
+                            <select className="form-select form-select-sm" title={t('theme.select')} id='themeSelector' value={theme} onChange={e => setTheme(e.target.value)}>
+                                <option value="light">{t('theme.light')}</option>
+                                <option value="dark">{t('theme.dark')}</option>
+                                <option value="pastel">{t('theme.pastel')}</option>
+                                <option value="ocean">{t('theme.ocean')}</option>
+                            </select>
+                            <small hmtlfor='themeLabel' id='themeHelp' className='form-text text-muted'>{t('theme.help')}</small>
+                        </div>
+                        <br />
+                        <div className='form-group'>
+                            <label className='label-description' htmlFor="bytesBaseInput">{t('byte.representation.description')}</label>
+                            <select className="form-select form-select-sm" title={t('byte.representation.select')} id='bytesBaseInput' value={bytesStringBase2} onChange={e => setByteStringBase(e.target.value)}>
+                                <option value="true">Base-2 (KiB, MiB, GiB, TiB)</option>
+                                <option value="false">Base-10 (KB, MB, GB, TB)</option>
+                            </select>
+                            <small hmtlfor='bytesBaseInput' id='bytesHelp' className='form-text text-muted'>{t('byte.representation.help')}</small>
+                        </div>
+                        <br />
+                        <div className='form-group'>
+                            <label className='label-description'>Appearance</label>
+                            <select className="form-select form-select-sm" title='Select font size' id='fontSizeInput' value={fontSize} onChange={e => setFontSize(e.target.value)}>
+                                <option value="fs-6">small</option>
+                                <option value="fs-5">medium</option>
+                                <option value="fs-4">large</option>
+                            </select>
+                            <small hmtlfor="fontSizeInput" id='fontSizeHelp' className='form-text text-muted'>Specifies the appearance of the user interface</small>
+                        </div>
+                        <br />
+                        <div className='form-group'>
+                            <label className='label-description'>Page size</label>
+                            <input className='form-control form-control-sm' id='pageSizeInput'
+                                type='text' placeholder='Page size' value={pageSize} disabled={true} />
+                            <small hmtlfor="pageSizeInput" id='pageSizeHelp' className='form-text text-muted'>Specifies the pagination size in tables</small>
+                        </div>
+                    </form >
+                </Accordion.Body>
+            </Accordion.Item>
+            <Accordion.Item eventKey="language">
+                <Accordion.Header>Language</Accordion.Header>
+                <Accordion.Body>
+                    <div className='form-group'>
+                        <label className='label-description'>{t('lang.description')}</label>
+                        <select className="form-select form-select-sm" title={t('lang.select')} id='languageInput' value={language} onChange={e => setLanguage(e.target.value)}>
+                            <option value="en-GB">{t('lang.en')}</option>
+                            <option value="de-DE">{t('lang.de')}</option>
+                            <option value="es-ES">{t('lang.es')}</option>
+                        </select>
+                        <small hmtlfor="languageInput" id='languageInputHelp' className='form-text text-muted'>{t('lang.help')}</small>
+                    </div>
+                </Accordion.Body>
+            </Accordion.Item>
+        </Accordion>
+    </>
 }
-Preferences.contextType = UIPreferencesContext

--- a/src/pages/Preferences.jsx
+++ b/src/pages/Preferences.jsx
@@ -36,20 +36,20 @@ export function Preferences() {
                         </div>
                         <br />
                         <div className='form-group'>
-                            <label className='label-description'>Appearance</label>
+                            <label className='label-description'>{t('user.interface.appearance')}</label>
                             <select className="form-select form-select-sm" title='Select font size' id='fontSizeInput' value={fontSize} onChange={e => setFontSize(e.target.value)}>
-                                <option value="fs-6">small</option>
-                                <option value="fs-5">medium</option>
-                                <option value="fs-4">large</option>
+                                <option value="fs-6">{t('user.interface.appearance.small')}</option>
+                                <option value="fs-5">{t('user.interface.appearance.medium')}</option>
+                                <option value="fs-4">{t('user.interface.appearance.large')}</option>
                             </select>
                             <small hmtlfor="fontSizeInput" id='fontSizeHelp' className='form-text text-muted'>Specifies the appearance of the user interface</small>
                         </div>
                         <br />
                         <div className='form-group'>
-                            <label className='label-description'>Page size</label>
+                            <label className='label-description'>{t('user.interface.pagesize.description')}</label>
                             <input className='form-control form-control-sm' id='pageSizeInput'
-                                type='text' placeholder='Page size' value={pageSize} disabled={true} />
-                            <small hmtlfor="pageSizeInput" id='pageSizeHelp' className='form-text text-muted'>Specifies the pagination size in tables</small>
+                                type='text' placeholder={t('user.interface.pagesize.hint')} value={pageSize} disabled={true} />
+                            <small hmtlfor="pageSizeInput" id='pageSizeHelp' className='form-text text-muted'>{t('user.interface.pagesize.help')}</small>
                         </div>
                     </form >
                 </Accordion.Body>
@@ -63,6 +63,10 @@ export function Preferences() {
                             <option value="en-GB">{t('lang.en')}</option>
                             <option value="de-DE">{t('lang.de')}</option>
                             <option value="es-ES">{t('lang.es')}</option>
+                            <option value="fr-FR">{t('lang.fr')}</option>
+                            <option value="it-IT">{t('lang.it')}</option>
+                            <option value="ru-RU">{t('lang.ru')}</option>
+                            <option value="jp-JP">{t('lang.jp')}</option>
                         </select>
                         <small hmtlfor="languageInput" id='languageInputHelp' className='form-text text-muted'>{t('lang.help')}</small>
                     </div>

--- a/src/utils/18ns.js
+++ b/src/utils/18ns.js
@@ -1,0 +1,17 @@
+import i18n from "i18next";
+import { initReactI18next } from "react-i18next";
+import backend from "i18next-http-backend";
+
+i18n
+  .use(backend)
+  .use(initReactI18next)
+  .init({
+    fallbackLng: "en-GB",
+    ns: ["translation"],
+    defaultNS: "translation",
+    interpolation: {
+      escapeValue: false,
+    },
+  });
+
+export default i18n;


### PR DESCRIPTION
Hi, 

this PR adds the multi-language support feature to ```kopia-ui```. Users can select their language in the preference tab. 
The following languages are supported:

- English
- German
- French
- Russian
- Italian
- Spanish
- Japanese (Maybe)

This PR also adds new libaries and dependencies (i18next, react-i18next, i18next-http-backend)

Cheers, 