### PR TITLE
fix(notifications): don't require login and password to allow using S…

### DIFF
--- a/src/components/notifications/EmailNotificationMethod.jsx
+++ b/src/components/notifications/EmailNotificationMethod.jsx
@@ -33,8 +33,8 @@ export class EmailNotificationMethod extends Component {
                 {RequiredNumberField(this, "SMTP Port", "smtpPort", { })}
             </Row>
             <Row>
-                {RequiredField(this, "SMTP Username", "smtpUsername", { placeholder: "SMTP server username, typically the email address" })}
-                {RequiredField(this, "SMTP Password", "smtpPassword", { placeholder: "SMTP server password", type: "password" })}
+                {OptionalField(this, "SMTP Username", "smtpUsername", { placeholder: "SMTP server username, typically the email address" })}
+                {OptionalField(this, "SMTP Password", "smtpPassword", { placeholder: "SMTP server password", type: "password" })}
                 {OptionalField(this, "SMTP Identity (Optional)", "smtpIdentity", { placeholder: "SMTP server identity (often empty)" })}
             </Row>
             <Row>


### PR DESCRIPTION
Don't require login and password for SMTP to omit using auth (and upgrading to SMTPs) to allow using just SMTP (for only internal smtp servers for example)