### PR TITLE
feat(ui): allow creating per-host, per-user and foreign policies

### DIFF
--- a/src/pages/Policies.jsx
+++ b/src/pages/Policies.jsx
@@ -12,7 +12,7 @@ import { Link } from 'react-router-dom';
 import { handleChange } from '../forms';
 import { OptionalDirectory } from '../forms/OptionalDirectory'
 import KopiaTable from '../utils/KopiaTable';
-import { CLIEquivalent, compare, isAbsolutePath, ownerName, policyEditorURL, redirect } from '../utils/uiutil';
+import { checkPolicyPath, CLIEquivalent, compare, isAbsolutePath, ownerName, policyEditorURL, redirect } from '../utils/uiutil';
 
 const applicablePolicies = "Applicable Policies"
 const localPolicies = "Local Path Policies"
@@ -103,8 +103,10 @@ export class Policies extends Component {
             return;
         }
 
-        if (!isAbsolutePath(this.state.policyPath)) {
-            alert("Policies can only be defined for absolute paths.");
+        const error = checkPolicyPath(this.state.policyPath, this.state.localHost, this.state.localUsername);
+
+        if (error) {
+            alert(error + "\nMust be either an absolute path, `user@host:/absolute/path`, `user@host` or `@host`. Use backslashes on Windows.");
             return;
         }
 


### PR DESCRIPTION
This PR addresses https://github.com/kopia/kopia/issues/4511

It relaxes the check for policy-creation to allow not just absolute paths, but also `user@host`, `@host` and `user@host:/absolute/path`