### PR TITLE
feat(ui): add max file size field to policy editor

### DIFF
--- a/src/components/policy-editor/PolicyEditor.jsx
+++ b/src/components/policy-editor/PolicyEditor.jsx
@@ -325,6 +325,11 @@ export class PolicyEditor extends Component {
                                 {EffectiveBooleanValue(this, "files.ignoreCacheDirs")}
                             </Row>
                             <Row>
+                                <LabelColumn name="Ignore Files larger than" help="When set, the files larger than the specified size are ignored (specified in bytes)" />
+                                <ValueColumn>{OptionalNumberField(this, "", "policy.files.maxFileSize")}</ValueColumn>
+                                {EffectiveValue(this, "files.maxFileSize")}
+                            </Row>
+                            <Row>
                                 <LabelColumn name="Scan only one filesystem" help="Do not cross filesystem boundaries when creating a snapshot" />
                                 <ValueColumn>{OptionalBoolean(this, null, "policy.files.oneFileSystem", "inherit from parent")}</ValueColumn>
                                 {EffectiveBooleanValue(this, "files.oneFileSystem")}


### PR DESCRIPTION
This PR adds the previously missing max file size field to the Policy Editor.

Values are specified in bytes. I tried allowing `KB`, etc. suffixes, but that turned out a little tricky wrt state management