### PR TITLE
fix(kopiaui): Remove misleading asterisk from extension placeholders

### DIFF
--- a/src/components/policy-editor/PolicyEditor.jsx
+++ b/src/components/policy-editor/PolicyEditor.jsx
@@ -387,14 +387,14 @@ export class PolicyEditor extends Component {
                             <Row>
                                 <LabelColumn name="Only Compress Extensions" help="Only compress files with the following file extensions (one extension per line)" />
                                 <WideValueColumn>
-                                    {StringList(this, "policy.compression.onlyCompress", { placeholder: "e.g. *.txt" })}
+                                    {StringList(this, "policy.compression.onlyCompress", { placeholder: "e.g. .txt" })}
                                 </WideValueColumn>
                                 {EffectiveTextAreaValue(this, "compression.onlyCompress")}
                             </Row>
                             <Row>
                                 <LabelColumn name="Never Compress Extensions" help="Never compress the following file extensions (one extension per line)" />
                                 <WideValueColumn>
-                                    {StringList(this, "policy.compression.neverCompress", { placeholder: "e.g. *.mp4" })}
+                                    {StringList(this, "policy.compression.neverCompress", { placeholder: "e.g. .mp4" })}
                                 </WideValueColumn>
                                 {EffectiveTextAreaValue(this, "compression.neverCompress")}
                             </Row>


### PR DESCRIPTION
When checking files' extensions for compression, Kopia [compares the result of `filepath.Ext()`](https://github.com/kopia/kopia/blob/dbf5bacdc8f33f47047350164d43ac18335d595d/snapshot/policy/compression_policy.go#L59), which returns the last `.` in the filename and the text following it. This means the extensions to enable/disable compression should be in the form `.txt`, not `*.txt`.

This PR changes the placeholder on the text inputs for the UI for the relevant text fields to just be `.txt` and `.mp4` rather than `*.txt` and `*.mp4`.