### PR TITLE
fix(htmui): restored retention labels

### DIFF
--- a/src/pages/SnapshotHistory.jsx
+++ b/src/pages/SnapshotHistory.jsx
@@ -357,10 +357,10 @@ export class SnapshotHistory extends Component {
                 {x.row.original.description && <div className='snapshot-description'><small>{x.row.original.description}</small></div>}</>,
         }, {
             header: 'Retention',
-            accessor: 'retention',
+            accessorFn: x => x.retention,
             width: "",
             cell: x => <span>
-                {/* {x.cell.getValue().map(l => <React.Fragment key={l}><Badge bg={"retention-badge-"+pillVariant(l)}>{l}</Badge>{' '}</React.Fragment>)} */}
+                {x.cell.getValue().map(l => <React.Fragment key={l}><Badge bg={"retention-badge-"+pillVariant(l)}>{l}</Badge>{' '}</React.Fragment>)}
                 {x.row.original.pins.map(l => <React.Fragment key={l}>
                     <Badge bg="snapshot-pin" onClick={() => this.editPin(x.row.original, l)}><FontAwesomeIcon icon={faThumbtack} /> {l}</Badge>{' '}
                 </React.Fragment>)}


### PR DESCRIPTION
As reported by @dcog989 in https://github.com/kopia/kopia/pull/4565

This was broken by https://github.com/kopia/htmlui/pull/317