### PR TITLE
Fix log font size / color contrast

### DIFF
--- a/src/css/App.css
+++ b/src/css/App.css
@@ -325,8 +325,8 @@ div.tab-body {
 }
 
 .logs-table {
-  font-family: monospace;
-  font-size: 70%;
+  font-famly: "Source Code Pro", source-code-pro, Menlo, Monaco, Consolas, "Courier New", monospace;
+  font-size: 75%;
   overflow: auto;
   max-height: 400px;
   border: 1px solid #aaa;

--- a/src/css/Theme.css
+++ b/src/css/Theme.css
@@ -42,8 +42,8 @@
   --color-text-nav: #cfcfcf;
   --color-text-form-help: #6c757d;
 
-  --color-error: #891905;
-  --color-danger: #891905;
+  --color-error: #fb917d;
+  --color-danger: #f5945f;
 
   --color-badge-warning: #c49508;
   --color-badge-primary: #47729a;

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -7,5 +7,5 @@ body {
 
 code {
   font-family:
-    source-code-pro, Menlo, Monaco, Consolas, "Courier New", monospace;
+    "Source Code Pro", source-code-pro, Menlo, Monaco, Consolas, "Courier New", monospace;
 }


### PR DESCRIPTION
Tweaked font colors to conform with WCAG contrast - was less than 2:1 (illegible), now 7:1 for `--color-error` and `--color-danger:`.

Also bumped size a little for the log listing, and added 'Source Code Pro' to monospace font stack.

Addresses #4459