### PR TITLE
feat(ui): Show restore completion percentage

### DIFF
--- a/src/utils/taskutil.jsx
+++ b/src/utils/taskutil.jsx
@@ -12,15 +12,27 @@ export function cancelTask(tid) {
     .catch((_error) => {});
 }
 
+export function taskProgressPercent(task) {
+  const match = task.progressInfo?.match(/(?:^|\s|\()([0-9]+(?:\.[0-9]+)?)%/);
+  return match ? match[1] + "%" : "";
+}
+
 export function taskStatusSymbol(task) {
   const st = task.status;
   const dur = formatDuration(task.startTime, task.endTime, true);
+  const progressPercent = taskProgressPercent(task);
 
   switch (st) {
     case "RUNNING":
       return (
         <>
           <Spinner animation="border" variant="primary" size="sm" /> Running for {dur}
+          {progressPercent && (
+            <>
+              {" "}
+              · <strong>{progressPercent}</strong>
+            </>
+          )}
           <button className="btn btn-sm btn-link" type="button" onClick={() => cancelTask(task.id)}>
             <FontAwesomeIcon color="red" size="lg" title="Cancel task" icon={faXmark} />
           </button>

--- a/tests/utils/uiutil-components.test.jsx
+++ b/tests/utils/uiutil-components.test.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import "@testing-library/jest-dom";
 
 import { sizeWithFailures } from "../../src/utils/uiutil";
-import { taskStatusSymbol } from "../../src/utils/taskutil";
+import { taskProgressPercent, taskStatusSymbol } from "../../src/utils/taskutil";
 
 describe("sizeWithFailures", () => {
   it("returns empty string for undefined size", () => {
@@ -84,6 +84,28 @@ describe("taskStatusSymbol", () => {
     // Look for text content that includes "Running for"
     const hasRunningText = children.some((child) => typeof child === "string" && child.includes("Running for"));
     expect(hasRunningText).toBe(true);
+  });
+
+  it("shows restore percentage for a running task", () => {
+    const task = {
+      ...baseTask,
+      status: "RUNNING",
+      endTime: null,
+      progressInfo: "Processed 0 of 1 items (250 MB of 1 GB) (25.0%), 12 MB/s, remaining 1m",
+    };
+    const result = taskStatusSymbol(task);
+
+    const progress = result.props.children.find(
+      (child) => child && typeof child === "object" && child.props?.children?.[2]?.props?.children === "25.0%",
+    );
+    expect(progress).toBeDefined();
+  });
+
+  it("extracts percentages without depending on restore wording", () => {
+    expect(taskProgressPercent({ progressInfo: "50% complete" })).toBe("50%");
+    expect(taskProgressPercent({ progressInfo: "Processed data (99.9%)" })).toBe("99.9%");
+    expect(taskProgressPercent({ progressInfo: "Scanning files" })).toBe("");
+    expect(taskProgressPercent({})).toBe("");
   });
 
   it("shows success status with check icon", () => {


### PR DESCRIPTION
## Summary

- extract a percentage from a task's `progressInfo`
- display it beside the elapsed time for running tasks
- leave statuses without percentage progress unchanged
- add coverage for integer, decimal, and missing percentages

## Why

Kopia reports detailed restore progress from the server, but the Tasks table previously showed only a spinner and elapsed time. Showing the percentage gives users a clear indication of whether a restore is near the beginning or completion.

This is the HTML UI portion of [kopia/kopia#3609](https://github.com/kopia/kopia/issues/3609). The companion server PR [kopia/kopia#5572](https://github.com/kopia/kopia/pull/5572) supplies restore progress for directory restores and individual file downloads.

## Validation

- `npm test -- --run tests/utils/uiutil-components.test.jsx` (14 tests passed)
- `npm run lint`
- `npm run prettier:check`
- `npm run build`

Tested end-to-end in a locally built macOS ARM64 KopiaUI application.
